### PR TITLE
Fix: Add programmatic navigation fallback

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -231,6 +231,26 @@ const router = new VueRouter({
   routes
 });
 
+// detect initial navigation
+let isInitialNavigation = false;
+router.beforeEach((to, from, next) => {
+  isInitialNavigation = from === VueRouter.START_LOCATION;
+  next();
+});
+
+// save original router.back() implementation bound to the initial router
+const originalRouterBack = router.back.bind(router);
+
+// substitute with the custom implementation
+router.back = async (): Promise<void> => {
+  if (isInitialNavigation && router.currentRoute.name !== 'home') {
+    await router.replace({ name: 'home' });
+    return;
+  }
+
+  originalRouterBack();
+};
+
 router.beforeEach((to, from, next) => {
   const { lang } = to.params;
   loadLanguageAsync(lang)

--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -10,6 +10,7 @@ export interface Globals {
   isIntercomEnabled: boolean;
   isSavingsMonthlyChartEnabled: boolean;
   isTreasuryMonthlyChartEnabled: boolean;
+  isNavigationFallbackEnabled: boolean;
 }
 
 const values: Globals = {
@@ -23,7 +24,8 @@ const values: Globals = {
   isNftDropsEnabled: false,
   isIntercomEnabled: false,
   isSavingsMonthlyChartEnabled: false,
-  isTreasuryMonthlyChartEnabled: false
+  isTreasuryMonthlyChartEnabled: false,
+  isNavigationFallbackEnabled: false
 };
 
 export const isFeatureEnabled = <T extends keyof Globals>(key: T): boolean =>

--- a/src/views/release-radar/release-radar-view-all.vue
+++ b/src/views/release-radar/release-radar-view-all.vue
@@ -66,9 +66,7 @@ export default Vue.extend({
   methods: {
     ...mapActions('modals', { setIsModalDisplayed: 'setIsDisplayed' }),
     handleClose(): void {
-      this.$router.push({
-        name: 'home'
-      });
+      this.$router.back();
     },
     async handleOpenSelectModal(): Promise<void> {
       const selectedAsset: Token | undefined = await this.setIsModalDisplayed({

--- a/src/views/savings/savings-root.vue
+++ b/src/views/savings/savings-root.vue
@@ -72,9 +72,7 @@ export default Vue.extend({
   },
   methods: {
     handleClose(): void {
-      this.$router.replace({
-        name: 'home'
-      });
+      this.$router.back();
     },
     replaceInactiveSavingsRoute(): void {
       this.$router.replace({

--- a/src/views/treasury/treasury-root.vue
+++ b/src/views/treasury/treasury-root.vue
@@ -75,9 +75,7 @@ export default Vue.extend({
   },
   methods: {
     handleClose(): void {
-      this.$router.replace({
-        name: 'home'
-      });
+      this.$router.back();
     },
     replaceInactiveTreasuryRoute(): void {
       this.$router.replace({


### PR DESCRIPTION
What was done
* Added a custom implementation of `router.back()` method
* Fixed invalid back button behavior (should not lead to the dashboard/home page always)
* Added a feature flag

How to test
* Enable `isNavigationFallbackAvailable` feature flag
* Make sure the provider is connected before following
* Visit `localhost:3000/savings` or `localhost:3000/treasury` from `page:blank` (important, to avoid previous navigation history)
* Click on 'back' navigation button
* Should be redirected to the `localhost:3000/` instead of `page:blank`