### PR TITLE
UX: Enable navigation fallback

### DIFF
--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -27,7 +27,7 @@ const values: Globals = {
   isIntercomEnabled: false,
   isSavingsMonthlyChartEnabled: false,
   isTreasuryMonthlyChartEnabled: false,
-  isNavigationFallbackEnabled: false
+  isNavigationFallbackEnabled: true
 };
 
 export const isFeatureEnabled = <T extends keyof Globals>(key: T): boolean =>


### PR DESCRIPTION
We've got a feature request from our users so here it is: navigation fallback preventing 'back' button from navigating all the way to the `page:blank`