### PR TITLE
[FIX[ Avatar `.type` of `undefined`

### DIFF
--- a/src/settings/persist/avatar.ts
+++ b/src/settings/persist/avatar.ts
@@ -49,7 +49,7 @@ export const getAvatarFromPersist = async (
   }
 
   const addressBoundItem = persistedItem[address];
-  if (addressBoundItem.type === undefined) {
+  if (addressBoundItem?.type === undefined) {
     return undefined; // compatibility check for Olympus NFT avatar feature
   }
 


### PR DESCRIPTION
What was done:
* Added an additional condition to check whether `addressBoundItem` is `undefined`

How to test:
* Not applicable