### PR TITLE
Chore: Use custom html5 picture

### DIFF
--- a/src/components/home/menu-list/menu-list-emoji-card-item.vue
+++ b/src/components/home/menu-list/menu-list-emoji-card-item.vue
@@ -2,23 +2,12 @@
   <li :class="itemClass">
     <router-link class="button-active" :to="{ name: this.navigateToName }">
       <div class="image">
-        <picture>
-          <source
-            :srcset="`
-              ${require(`@/assets/images/${pic}@1x.webp`)},
-              ${require(`@/assets/images/${pic}@2x.webp`)} 2x
-            `"
-            type="image/webp"
-          />
-          <img
-            alt=""
-            :src="`${require(`@/assets/images/${pic}@1x.png`)}`"
-            :srcset="`
-              ${require(`@/assets/images/${pic}@1x.png`)},
-              ${require(`@/assets/images/${pic}@2x.png`)} 2x
-            `"
-          />
-        </picture>
+        <custom-picture
+          alt=""
+          :sources="pictureSources"
+          :src="src"
+          :webp-sources="pictureWebpSources"
+        />
       </div>
       <div class="info">
         <h3>{{ title }}</h3>
@@ -31,8 +20,11 @@
 <script lang="ts">
 import Vue from 'vue';
 
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
+
 export default Vue.extend({
   name: 'MenuListEmojiCardItem',
+  components: { CustomPicture },
   props: {
     pic: {
       type: String,
@@ -63,9 +55,16 @@ export default Vue.extend({
 
       return '';
     },
-    srcsetWebp(): string {
-      return `@/assets/images/${this.pic}@1x.webp,
-              @/assets/images/${this.pic}@2x.webp 2x`;
+    pictureSources(): Array<PictureSourceDescriptor> {
+      return [
+        { src: require(`@/assets/images/${this.pic}@2x.png`), variant: '2x' }
+      ];
+    },
+    pictureWebpSources(): Array<PictureSourceDescriptor> {
+      return [
+        { src: require(`@/assets/images/${this.pic}@1x.webp`) },
+        { src: require(`@/assets/images/${this.pic}@2x.webp`), variant: '2x' }
+      ];
     },
     src(): string {
       return `@/assets/images/${this.pic}@1x.png`;

--- a/src/components/html5/custom-picture.vue
+++ b/src/components/html5/custom-picture.vue
@@ -1,7 +1,7 @@
 <template>
-  <picture>
+  <picture :style="containerStyle">
     <source v-if="webpSrcset !== ''" :srcset="webpSrcset" type="image/webp" />
-    <img :alt="alt" :src="src" :srcset="imageSrcSet" />
+    <img :alt="alt" :src="src" :srcset="imageSrcSet" :style="pictureStyle" />
   </picture>
 </template>
 
@@ -10,6 +10,7 @@ import Vue, { PropType } from 'vue';
 
 import { formatPictureSources } from './utils';
 import { PictureSourceDescriptor } from './types';
+import { Properties } from 'csstype';
 
 export default Vue.extend({
   name: 'CustomPicture',
@@ -29,6 +30,14 @@ export default Vue.extend({
     webpSources: {
       type: Array as PropType<Array<PictureSourceDescriptor>>,
       default: () => []
+    },
+    containerStyle: {
+      type: [String, Object] as PropType<string | Properties>,
+      default: undefined
+    },
+    pictureStyle: {
+      type: [String, Object] as PropType<string | Properties>,
+      default: undefined
     }
   },
   computed: {

--- a/src/components/modals/details-picture.vue
+++ b/src/components/modals/details-picture.vue
@@ -1,0 +1,34 @@
+<template>
+  <custom-picture
+    :alt="$t('icon.txtSwapDetailsIconAlt')"
+    :sources="pictureSources"
+    :src="pictureSrc"
+    :webp-sources="pictureWebpSources"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
+
+export default Vue.extend({
+  name: 'DetailsPicture',
+  components: {
+    CustomPicture
+  },
+  data() {
+    return {
+      pictureSrc: require('@/assets/images/Details.png'),
+      pictureSources: [
+        { src: require('@/assets/images/Details.png') },
+        { src: require('@/assets/images/Details@2x.png'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>,
+      pictureWebpSources: [
+        { src: require('@/assets/images/Details.webp') },
+        { src: require('@/assets/images/Details@2x.webp'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>
+    };
+  }
+});
+</script>

--- a/src/components/modals/eth-picture.vue
+++ b/src/components/modals/eth-picture.vue
@@ -1,0 +1,33 @@
+<template>
+  <custom-picture
+    :alt="$t('asset.txtAlt', { name: 'ETH' })"
+    :picture-style="pictureStyles"
+    :sources="pictureSources"
+    :src="pictureSrc"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
+
+export default Vue.extend({
+  name: 'EthPicture',
+  components: {
+    CustomPicture
+  },
+  data() {
+    return {
+      pictureSrc: require('@/assets/images/ETH.png'),
+      pictureSources: [
+        { src: require('@/assets/images/ETH.png') },
+        { src: require('@/assets/images/ETH@2x.png'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>,
+      pictureStyles: {
+        boxShadow: '0px 0px 16px rgba(53, 119, 190, 1)'
+      }
+    };
+  }
+});
+</script>

--- a/src/components/modals/flip-picture.vue
+++ b/src/components/modals/flip-picture.vue
@@ -1,0 +1,34 @@
+<template>
+  <custom-picture
+    :alt="$t('icon.txtFlipAssetsIconAlt')"
+    :sources="pictureSources"
+    :src="pictureSrc"
+    :webp-sources="pictureWebpSources"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
+
+export default Vue.extend({
+  name: 'FlipPicture',
+  components: {
+    CustomPicture
+  },
+  data() {
+    return {
+      pictureSrc: require('@/assets/images/Flip.png'),
+      pictureSources: [
+        { src: require('@/assets/images/Flip.png') },
+        { src: require('@/assets/images/Flip@2x.png'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>,
+      pictureWebpSources: [
+        { src: require('@/assets/images/Flip.webp') },
+        { src: require('@/assets/images/Flip@2x.webp'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>
+    };
+  }
+});
+</script>

--- a/src/components/modals/move-picture.vue
+++ b/src/components/modals/move-picture.vue
@@ -1,0 +1,33 @@
+<template>
+  <custom-picture
+    :alt="$t('asset.txtAlt', { name: 'MOVE' })"
+    :picture-style="pictureStyles"
+    :sources="pictureSources"
+    :src="pictureSrc"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
+
+export default Vue.extend({
+  name: 'MovePicture',
+  components: {
+    CustomPicture
+  },
+  data() {
+    return {
+      pictureSrc: require('@/assets/images/MOVE.png'),
+      pictureSources: [
+        { src: require('@/assets/images/MOVE.png') },
+        { src: require('@/assets/images/MOVE@2x.png'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>,
+      pictureStyles: {
+        boxShadow: '0px 0px 16px rgb(195, 236, 52)'
+      }
+    };
+  }
+});
+</script>

--- a/src/components/modals/savings-deposit-modal.vue
+++ b/src/components/modals/savings-deposit-modal.vue
@@ -35,23 +35,7 @@
           type="button"
           @click="expandInfo"
         >
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Details.webp,
-                @/assets/images/Details@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtSwapDetailsIconAlt')"
-              src="@/assets/images/Details.png"
-              srcset="
-                @/assets/images/Details.png,
-                @/assets/images/Details@2x.png 2x
-              "
-            />
-          </picture>
+          <details-picture />
           <span>Deposit Details</span>
         </button>
         <div v-if="showInfo" class="tx-details__content">
@@ -59,17 +43,7 @@
             <p class="description">Swapping for</p>
             <div class="value">
               <div class="icon">
-                <picture>
-                  <img
-                    alt=""
-                    src="@/assets/images/USDC.png"
-                    srcset="
-                      @/assets/images/USDC.png,
-                      @/assets/images/USDC@2x.png 2x
-                    "
-                    style="box-shadow: rgb(36, 116, 204) 0px 0px 8px"
-                  />
-                </picture>
+                <usdc-picture />
               </div>
               <span>{{ swappingForString }}</span>
             </div>
@@ -110,6 +84,10 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { mapGetters, mapState } from 'vuex';
+import Web3 from 'web3';
+import * as Sentry from '@sentry/vue';
+import { Properties as CssProperties } from 'csstype';
 
 import {
   TokenWithBalance,
@@ -117,19 +95,12 @@ import {
   SmallTokenInfoWithIcon,
   GasData
 } from '@/wallet/types';
-
-import { AssetField, GasSelector, FormLoader } from '@/components/controls';
-import { ActionButton } from '@/components/buttons';
-import { GasMode, GasModeData } from '@/components/controls/gas-selector.vue';
-
 import {
   getTransferData,
   TransferData,
   ZeroXSwapError
 } from '@/services/0x/api';
 import { mapError } from '@/services/0x/errors';
-import Web3 from 'web3';
-import { mapGetters, mapState } from 'vuex';
 import {
   add,
   convertAmountFromNativeValue,
@@ -150,13 +121,17 @@ import { estimateDepositCompound } from '@/wallet/actions/savings/deposit/deposi
 import { formatToNative } from '@/utils/format';
 import { sameAddress } from '@/utils/address';
 import { isSubsidizedAllowed } from '@/wallet/actions/subsidized';
-import * as Sentry from '@sentry/vue';
 import {
   Modal as ModalTypes,
   TModalPayload
 } from '@/store/modules/modals/types';
+
 import Modal from './modal.vue';
-import { Properties as CssProperties } from 'csstype';
+import { AssetField, GasSelector, FormLoader } from '@/components/controls';
+import { ActionButton } from '@/components/buttons';
+import { GasMode, GasModeData } from '@/components/controls/gas-selector.vue';
+import UsdcPicture from './usdc-picture.vue';
+import DetailsPicture from './details-picture.vue';
 
 export default Vue.extend({
   name: 'SavingsDepositModal',
@@ -165,7 +140,9 @@ export default Vue.extend({
     ActionButton,
     GasSelector,
     FormLoader,
-    Modal
+    Modal,
+    UsdcPicture,
+    DetailsPicture
   },
   data() {
     return {

--- a/src/components/modals/savings-withdraw-modal.vue
+++ b/src/components/modals/savings-withdraw-modal.vue
@@ -36,23 +36,7 @@
           type="button"
           @click="expandInfo"
         >
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Details.webp,
-                @/assets/images/Details@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtSwapDetailsIconAlt')"
-              src="@/assets/images/Details.png"
-              srcset="
-                @/assets/images/Details.png,
-                @/assets/images/Details@2x.png 2x
-              "
-            />
-          </picture>
+          <details-picture />
           <span>Withdraw Details</span>
         </button>
         <div v-if="showInfo" class="tx-details__content">
@@ -128,6 +112,7 @@ import {
   Modal as ModalTypes,
   TModalPayload
 } from '@/store/modules/modals/types';
+import DetailsPicture from '@/components/modals/details-picture.vue';
 
 export default Vue.extend({
   name: 'SavingsWithdrawModal',
@@ -136,7 +121,8 @@ export default Vue.extend({
     ActionButton,
     GasSelector,
     FormLoader,
-    Modal
+    Modal,
+    DetailsPicture
   },
   data() {
     return {

--- a/src/components/modals/search-modal/search-modal-token-item.vue
+++ b/src/components/modals/search-modal/search-modal-token-item.vue
@@ -20,17 +20,12 @@
       class="swaps__wrapper-search-items-item-button"
     >
       <a class="button-active" :href="infoButtonSrc" target="_blank">
-        <picture>
-          <source
-            srcset="@/assets/images/info.webp, @/assets/images/info2x.webp 2x"
-            type="image/webp"
-          />
-          <img
-            :alt="$t('icon.txtTokenInfoAlt')"
-            src="@/assets/images/info.png"
-            srcset="@/assets/images/info.png, @/assets/images/info2x.png 2x"
-          />
-        </picture>
+        <custom-picture
+          :alt="$t('icon.txtTokenInfoAlt', { name: item.name })"
+          :sources="pictureSources"
+          :src="require('@/assets/images/info.png')"
+          :webp-sources="pictureWebpSources"
+        />
       </a>
     </div>
   </div>
@@ -42,11 +37,13 @@ import BigNumber from 'bignumber.js';
 
 import { isTokenWithBalance, Token, TokenWithBalance } from '@/wallet/types';
 import { TokenImage } from '@/components/tokens';
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
 
 export default Vue.extend({
   name: 'SearchModalTokenItem',
   components: {
-    TokenImage
+    TokenImage,
+    CustomPicture
   },
   props: {
     item: {
@@ -57,6 +54,18 @@ export default Vue.extend({
       type: Boolean,
       default: false
     }
+  },
+  data() {
+    return {
+      pictureSources: [
+        { src: require('@/assets/images/info.png') },
+        { src: require('@/assets/images/info2x.png'), variant: '2x' }
+      ],
+      pictureWebpSources: [
+        { src: require('@/assets/images/info.webp') },
+        { src: require('@/assets/images/info2x.webp'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>
+    };
   },
   computed: {
     assetBalance(): string {

--- a/src/components/modals/swap-modal.vue
+++ b/src/components/modals/swap-modal.vue
@@ -44,20 +44,7 @@
       </div>
       <div class="modal-wrapper-info-buttons">
         <button class="flip button-active" type="button" @click="flipAssets">
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Flip.webp,
-                @/assets/images/Flip@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtFlipAssetsIconAlt')"
-              src="@/assets/images/Flip.png"
-              srcset="@/assets/images/Flip.png, images/Flip@2x.png 2x"
-            />
-          </picture>
+          <flip-picture />
           <span>Flip</span>
         </button>
         <button
@@ -66,23 +53,7 @@
           type="button"
           @click="expandInfo"
         >
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Details.webp,
-                @/assets/images/Details@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtSwapDetailsIconAlt')"
-              src="@/assets/images/Details.png"
-              srcset="
-                @/assets/images/Details.png,
-                @/assets/images/Details@2x.png 2x
-              "
-            />
-          </picture>
+          <details-picture />
           <span>Swap Details</span>
         </button>
         <div v-if="showInfo" class="tx-details__content">
@@ -140,8 +111,11 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import Web3 from 'web3';
 import { mapGetters, mapState } from 'vuex';
+import Web3 from 'web3';
+import { Properties as CssProperties } from 'csstype';
+import * as Sentry from '@sentry/vue';
+
 import { estimateSwapCompound } from '@/wallet/actions/swap/swapEstimate';
 import { swapCompound } from '@/wallet/actions/swap/swap';
 import {
@@ -167,6 +141,8 @@ import { formatSwapSources, getMoveAssetData } from '@/wallet/references/data';
 import { TokenWithBalance, Token, SmallToken, GasData } from '@/wallet/types';
 import { GetTokenPrice } from '@/services/thegraph/api';
 import { sameAddress } from '@/utils/address';
+import ethDefaults from '@/wallet/references/defaults';
+import { isSubsidizedAllowed } from '@/wallet/actions/subsidized';
 
 import {
   AssetField,
@@ -178,15 +154,13 @@ import { ActionButton } from '@/components/buttons';
 import { GasMode, GasModeData } from '@/components/controls/gas-selector.vue';
 import { Slippage } from '../controls/slippage-selector.vue';
 import { Step } from '@/components/controls/form-loader';
-import ethDefaults from '@/wallet/references/defaults';
-import { isSubsidizedAllowed } from '@/wallet/actions/subsidized';
-import { Properties as CssProperties } from 'csstype';
-import * as Sentry from '@sentry/vue';
-import Modal from '@/components/modals/modal.vue';
 import {
   Modal as ModalTypes,
   TModalPayload
 } from '@/store/modules/modals/types';
+import Modal from '@/components/modals/modal.vue';
+import DetailsPicture from './details-picture.vue';
+import FlipPicture from './flip-picture.vue';
 
 export default Vue.extend({
   name: 'SwapModal',
@@ -196,7 +170,9 @@ export default Vue.extend({
     GasSelector,
     SlippageSelector,
     FormLoader,
-    Modal
+    Modal,
+    DetailsPicture,
+    FlipPicture
   },
   data() {
     return {

--- a/src/components/modals/treasury-claim-and-burn-modal.vue
+++ b/src/components/modals/treasury-claim-and-burn-modal.vue
@@ -34,23 +34,7 @@
           type="button"
           @click="expandInfo"
         >
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Details.webp,
-                @/assets/images/Details@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtSwapDetailsIconAlt')"
-              src="@/assets/images/Details.png"
-              srcset="
-                @/assets/images/Details.png,
-                @/assets/images/Details@2x.png 2x
-              "
-            />
-          </picture>
+          <details-picture />
           <span>Transaction Details</span>
         </button>
         <div v-if="showInfo" class="tx-details__content">
@@ -58,17 +42,7 @@
             <p class="description">Claiming for</p>
             <div class="value">
               <div class="icon">
-                <picture>
-                  <img
-                    alt=""
-                    src="@/assets/images/USDC.png"
-                    srcset="
-                      @/assets/images/USDC.png,
-                      @/assets/images/USDC@2x.png 2x
-                    "
-                    style="box-shadow: rgb(36, 116, 204) 0px 0px 8px"
-                  />
-                </picture>
+                <usdc-picture />
               </div>
               <span>{{ claimingForStr }}</span>
             </div>
@@ -94,17 +68,7 @@
         <p>
           Claim &amp; Burn allows you to exchange your
           <span class="icon">
-            <picture>
-              <img
-                alt=""
-                src="@/assets/images/MOVE.png"
-                srcset="
-                  @/assets/images/MOVE.png,
-                  @/assets/images/MOVE@2x.png 2x
-                "
-                style="box-shadow: 0px 0px 16px rgb(195, 236, 52)"
-              />
-            </picture>
+            <move-picture />
           </span>
           MOVE tokens for a larger portion of the Smart Treasury. You will burn
           your MOVE tokens, and receive four times (4x) of your treasury share
@@ -118,7 +82,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
-import { Properties } from 'csstype';
+import { Properties as CssProperties } from 'csstype';
 
 import { TokenWithBalance, SmallToken, GasData } from '@/wallet/types';
 import {
@@ -146,7 +110,9 @@ import { ActionButton } from '@/components/buttons';
 import { GasMode, GasModeData } from '@/components/controls/gas-selector.vue';
 import { Step } from '@/components/controls/form-loader';
 import Modal from './modal.vue';
-import { Properties as CssProperties } from 'csstype';
+import DetailsPicture from '@/components/modals/details-picture.vue';
+import UsdcPicture from '@/components/modals/usdc-picture.vue';
+import MovePicture from '@/components/modals/move-picture.vue';
 
 export default Vue.extend({
   name: 'TreasuryIncreaseBoostModal',
@@ -155,7 +121,10 @@ export default Vue.extend({
     ActionButton,
     GasSelector,
     FormLoader,
-    Modal
+    Modal,
+    MovePicture,
+    UsdcPicture,
+    DetailsPicture
   },
   data() {
     return {
@@ -293,7 +262,7 @@ export default Vue.extend({
     showInfo(): boolean {
       return this.infoExpanded && this.isInfoAvailable;
     },
-    coinImageStyle(): Properties {
+    coinImageStyle(): CssProperties {
       return {
         boxShadow: 'rgb(182, 222, 49) 0px 0px 16px'
       };

--- a/src/components/modals/treasury-decrease-boost-modal.vue
+++ b/src/components/modals/treasury-decrease-boost-modal.vue
@@ -35,23 +35,7 @@
           type="button"
           @click="expandInfo"
         >
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Details.webp,
-                @/assets/images/Details@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtSwapDetailsIconAlt')"
-              src="@/assets/images/Details.png"
-              srcset="
-                @/assets/images/Details.png,
-                @/assets/images/Details@2x.png 2x
-              "
-            />
-          </picture>
+          <details-picture />
           <span>Transaction Details</span>
         </button>
         <div v-if="showInfo" class="tx-details__content">
@@ -88,9 +72,9 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import { TokenWithBalance, SmallToken, GasData } from '@/wallet/types';
+import { GasData, SmallToken, TokenWithBalance } from '@/wallet/types';
 
-import { AssetField, GasSelector, FormLoader } from '@/components/controls';
+import { AssetField, FormLoader, GasSelector } from '@/components/controls';
 import { ActionButton } from '@/components/buttons';
 import { GasMode, GasModeData } from '@/components/controls/gas-selector.vue';
 
@@ -123,6 +107,7 @@ import Modal from './modal.vue';
 import { Step } from '../controls/form-loader';
 import { calcTreasuryBoost } from '@/store/modules/account/utils/treasury';
 import { Properties as CssProperties } from 'csstype';
+import DetailsPicture from '@/components/modals/details-picture.vue';
 
 export default Vue.extend({
   name: 'TreasuryDecreaseBoostModal',
@@ -131,7 +116,8 @@ export default Vue.extend({
     ActionButton,
     GasSelector,
     FormLoader,
-    Modal
+    Modal,
+    DetailsPicture
   },
   data() {
     return {
@@ -185,13 +171,12 @@ export default Vue.extend({
         this.moveNativePrice,
         this.slpNativePrice
       );
-      const res = treasuryTokens
+      return treasuryTokens
         .map((t) => ({
           ...t,
           balance: this.getTreasuryTokenBalance(t.address)
         }))
         .filter((t) => greaterThan(t.balance, '0'));
-      return res;
     },
     error(): string | undefined {
       if (!notZero(this.output.amount)) {

--- a/src/components/modals/treasury-increase-boost-modal.vue
+++ b/src/components/modals/treasury-increase-boost-modal.vue
@@ -36,23 +36,7 @@
           type="button"
           @click="expandInfo"
         >
-          <picture>
-            <source
-              srcset="
-                @/assets/images/Details.webp,
-                @/assets/images/Details@2x.webp 2x
-              "
-              type="image/webp"
-            />
-            <img
-              :alt="$t('icon.txtSwapDetailsIconAlt')"
-              src="@/assets/images/Details.png"
-              srcset="
-                @/assets/images/Details.png,
-                @/assets/images/Details@2x.png 2x
-              "
-            />
-          </picture>
+          <details-picture />
           <span>Transaction Details</span>
         </button>
         <div v-if="showInfo" class="tx-details__content">
@@ -83,43 +67,16 @@
         <p>
           There are two boost options. Reserving
           <span class="icon">
-            <picture>
-              <img
-                alt=""
-                src="@/assets/images/MOVE.png"
-                srcset="
-                  @/assets/images/MOVE.png,
-                  @/assets/images/MOVE@2x.png 2x
-                "
-              />
-            </picture>
+            <move-picture />
           </span>
           MOVE tokens will increase (1x) your rewards share based on the total
           amount of the tokens you have reserved. Reserving
           <span class="icon-wrapper">
             <span class="icon-left">
-              <picture>
-                <img
-                  alt=""
-                  src="@/assets/images/MOVE.png"
-                  srcset="
-                    @/assets/images/MOVE.png,
-                    @/assets/images/MOVE@2x.png 2x
-                  "
-                />
-              </picture>
+              <move-picture />
             </span>
             <span class="icon-right">
-              <picture>
-                <img
-                  alt=""
-                  src="@/assets/images/ETH.png"
-                  srcset="
-                    @/assets/images/ETH.png,
-                    @/assets/images/ETH@2x.png 2x
-                  "
-                />
-              </picture>
+              <eth-picture />
             </span>
           </span>
           MOVE-ETH LP tokens will multiply by 2,5 (2.5x) your rewards share
@@ -169,6 +126,9 @@ import {
 
 import Modal from './modal.vue';
 import { calcTreasuryBoost } from '@/store/modules/account/utils/treasury';
+import DetailsPicture from '@/components/modals/details-picture.vue';
+import MovePicture from '@/components/modals/move-picture.vue';
+import EthPicture from '@/components/modals/eth-picture.vue';
 
 export default Vue.extend({
   name: 'TreasuryIncreaseBoostModal',
@@ -177,7 +137,10 @@ export default Vue.extend({
     ActionButton,
     GasSelector,
     FormLoader,
-    Modal
+    Modal,
+    EthPicture,
+    MovePicture,
+    DetailsPicture
   },
   data() {
     return {

--- a/src/components/modals/usdc-picture.vue
+++ b/src/components/modals/usdc-picture.vue
@@ -1,0 +1,33 @@
+<template>
+  <custom-picture
+    :alt="$t('asset.txtAlt', { name: 'USDC' })"
+    :picture-style="pictureStyles"
+    :sources="pictureSources"
+    :src="pictureSrc"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import { CustomPicture, PictureSourceDescriptor } from '@/components/html5';
+
+export default Vue.extend({
+  name: 'UsdcPicture',
+  components: {
+    CustomPicture
+  },
+  data() {
+    return {
+      pictureSrc: require('@/assets/images/USDC.png'),
+      pictureSources: [
+        { src: require('@/assets/images/USDC.png') },
+        { src: require('@/assets/images/USDC@2x.png'), variant: '2x' }
+      ] as Array<PictureSourceDescriptor>,
+      pictureStyles: {
+        boxShadow: 'rgb(36, 116, 204) 0px 0px 8px'
+      }
+    };
+  }
+});
+</script>

--- a/src/components/sections/section-base/section-base-link.vue
+++ b/src/components/sections/section-base/section-base-link.vue
@@ -12,14 +12,12 @@
     class="link-icon button-active"
     :to="{ name: navigateToName }"
   >
-    <picture>
-      <custom-picture
-        :alt="$t('icon.txtNavigationLinkAlt')"
-        :sources="picture.sources"
-        :src="picture.src"
-        :webp-sources="picture.webpSources"
-      />
-    </picture>
+    <custom-picture
+      :alt="$t('icon.txtNavigationLinkAlt')"
+      :sources="picture.sources"
+      :src="picture.src"
+      :webp-sources="picture.webpSources"
+    />
   </router-link>
 </template>
 
@@ -32,6 +30,7 @@ const picture: PictureDescriptor = {
   alt: '', // not used
   src: require('@/assets/images/open_icon.png'),
   sources: [
+    { src: require('@/assets/images/open_icon.png') },
     {
       src: require('@/assets/images/open_icon@2x.png'),
       variant: '2x'


### PR DESCRIPTION
What was done
* Updated `<custom-picture>` component to pass styles (primarily for shadowing effect)
* Added new components to be reused (eth, move, usdc, details, flip icons)
* Updated components using `<picture>` to use `<custom-picture>` or it's derivatives

How to test
* Perform a brief check over each component that is changed, ensure nothing's broken