### PR TITLE
[Fix] Governance: Prevent double voting

### DIFF
--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -642,7 +642,7 @@ if (isFeatureEnabled('isGovernanceEnabled')) {
       'voting is not started yet': 'Oh no. Voting is not started yet',
       'voting is closed': 'Oh no. Voting is already closed',
       'wrong timestamp':
-        'Oh no. The request took too long or the system time on your device is out of sync. Please try again'
+        "Oh no. The request too long, or our system is out of sync. Looks like you'll have to try again later"
     },
     btnTogglePreview: 'Toggle preview',
     txtTogglePreview: 'Toggle markdown preview',

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -638,7 +638,11 @@ if (isFeatureEnabled('isGovernanceEnabled')) {
       'not enough power to vote':
         "Oh no. Seems like you don't have enough power to vote",
       'not enough power to create a proposal':
-        "Oh no. Seems like you don't have enough power to create a proposal"
+        "Oh no. Seems like you don't have enough power to create a proposal",
+      'voting is not started yet': 'Oh no. Voting is not started yet',
+      'voting is closed': 'Oh no. Voting is already closed',
+      'wrong timestamp':
+        'Oh no. The request took too long or the system time on your device is out of sync. Please try again'
     },
     btnTogglePreview: 'Toggle preview',
     txtTogglePreview: 'Toggle markdown preview',

--- a/src/services/mover/governance/client.ts
+++ b/src/services/mover/governance/client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
+import dayjs from 'dayjs';
 import Web3 from 'web3';
 
 import { defaultClientVersion } from './consts';
@@ -167,7 +168,7 @@ export default class Client {
       address: accountAddress,
       msg: JSON.stringify({
         version: this.clientVersion,
-        timestamp: (Date.now() / 1e3).toFixed(),
+        timestamp: dayjs().unix().toFixed(),
         space: spaceId,
         type,
         payload

--- a/src/store/modules/governance/actions.ts
+++ b/src/store/modules/governance/actions.ts
@@ -24,6 +24,7 @@ import {
   ProposalInfo,
   ProposalWithVotes,
   Scores,
+  Vote,
   vote,
   VoteParams,
   VoteResponse
@@ -202,6 +203,15 @@ export default {
         return await loadFreshData();
       }
 
+      const now = dayjs().unix();
+      if (
+        state.items[existingItemIdx].proposal.state !== 'closed' &&
+        now > state.items[existingItemIdx].proposal.end
+      ) {
+        // should be already closed but still is valid cached item
+        return await loadFreshData();
+      }
+
       return state.items[existingItemIdx];
     } catch (error) {
       console.error('failed to get single proposal', error);
@@ -254,7 +264,7 @@ export default {
     }
   },
   async vote(
-    { state, rootState, getters },
+    { state, commit, rootState, getters },
     payload: VoteParams
   ): Promise<VoteResponse> {
     try {
@@ -266,6 +276,25 @@ export default {
         throw new Error('failed to get current address');
       }
 
+      const storedProposal = state.items.find(
+        (info) => info.proposal.id === payload.proposal
+      );
+      if (storedProposal === undefined) {
+        // although should not happen, TypeScript doesn't know
+        // anything about that so throw an error like 'never' :)
+        throw new Error('failed to find stored proposal');
+      }
+
+      const now = dayjs().unix();
+
+      if (now < storedProposal.proposal.start) {
+        throw new GovernanceApiError('voting is not started yet');
+      }
+
+      if (now > storedProposal.proposal.end) {
+        throw new GovernanceApiError('voting is closed');
+      }
+
       if (getters.isAlreadyVoted(payload.proposal)) {
         throw new GovernanceApiError('already voted');
       }
@@ -274,12 +303,35 @@ export default {
         throw new GovernanceApiError('not enough power to vote');
       }
 
-      return await vote(
+      const result = await vote(
         rootState.account.provider.web3,
         rootState.account.currentAddress,
         state.spaceId,
         payload
       );
+
+      // manually add vote record in case of
+      // subsequent refetch request fails
+      commit('upsertItems', {
+        ...storedProposal,
+        votes: storedProposal.votes.concat({
+          choice: payload.choice,
+          created: now,
+          id: result.id,
+          ipfs: result.ipfsHash,
+          voter: rootState.account.currentAddress
+        }),
+        scores: {
+          ...storedProposal.scores,
+          all: storedProposal.scores.all.map((scoresGroup) => ({
+            ...scoresGroup,
+            [rootState.account?.currentAddress ?? 'missing_address']:
+              state.votingPowerSelf
+          }))
+        }
+      } as ProposalInfo);
+
+      return result;
     } catch (error) {
       console.error('failed to vote', error);
 

--- a/src/store/modules/governance/actions.ts
+++ b/src/store/modules/governance/actions.ts
@@ -24,7 +24,6 @@ import {
   ProposalInfo,
   ProposalWithVotes,
   Scores,
-  Vote,
   vote,
   VoteParams,
   VoteResponse


### PR DESCRIPTION
Context
* Users were able to vote twice/more (depending on scenario and on what step they got an exceptional state)
  * Although double voting is technically possible, it does not change anything really as only first vote counts
* If the command request takes `~5mins` to reach the server (**which is an exceptional situation by itself but definitely possible** by not confirming a message sign for long enough / bad internet connection), it always fails

What was done
* Added boundary checks for vote function (to prevent voting for/against inactive (pending / closed) proposals on the client side (to fail fast on early step and not make a request to the server each time))
* Add force update scenario: if a proposal is not closed but should be (proposal.end < now), the action will forcefully refetch the whole entry
* Updated `Client` to use `dayjs().unix().toFixed()` as a value instead of `Date.now()` to be more consistent codebase-wise
* Added user-friendly message for special case with wrong timestamp