### PR TITLE
[Fix] Remove time-consuming console.log

### DIFF
--- a/src/components/modals/search-modal/search-modal-token-item.vue
+++ b/src/components/modals/search-modal/search-modal-token-item.vue
@@ -72,7 +72,6 @@ export default Vue.extend({
   computed: {
     assetBalance(): string {
       if (isTokenWithBalance(this.item)) {
-        console.log(this.item);
         return new BigNumber(this.item.balance).decimalPlaces(4).toFormat();
       }
       return '0';


### PR DESCRIPTION
Context
* This component is actually one of the most time-consuming ones
* Because of that, no unneeded actions should be here

What was done
* Removed console.log from `search-modal-token-item.vue`