### PR TITLE
[Fix] Dynamic input initial width

### DIFF
--- a/src/components/controls/dynamic-input.vue
+++ b/src/components/controls/dynamic-input.vue
@@ -85,7 +85,7 @@ export default Vue.extend({
     }
   },
   mounted() {
-    this.calcWidth('0.00');
+    this.calcWidth(this.value !== '' ? this.value : '0.00');
   },
   methods: {
     calcWidth(newVal: string): void {


### PR DESCRIPTION
Context
* During `<dynamic-input>`  `mounted()` lifecycle hook in case of non-empty value the width of input is calculated wrong
* It should have a width of value passed through the `props` but it is computed as `0.00`'s length

What was done
* Implemented prop-dependent input width calculation