### PR TITLE
[Fix] Wrong timestamp error text typo

### DIFF
--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -632,7 +632,7 @@ if (isFeatureEnabled('isGovernanceEnabled')) {
       'voting is not started yet': 'Oh no. Voting is not started yet',
       'voting is closed': 'Oh no. Voting is already closed',
       'wrong timestamp':
-        "Oh no. The request too long, or our system is out of sync. Looks like you'll have to try again later"
+        "Oh no. The request too long, or your system is out of sync. Looks like you'll have to try again later"
     },
     btnTogglePreview: 'Toggle preview',
     txtTogglePreview: 'Toggle markdown preview',


### PR DESCRIPTION
Context
* `our` -> `your`

What was done
* Fixed the typo