### PR TITLE
[Feature] Gas listener on demand

### DIFF
--- a/src/components/treasury/treasury-powercard-empty.vue
+++ b/src/components/treasury/treasury-powercard-empty.vue
@@ -61,6 +61,7 @@ import { mapActions, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 
 import { greaterThan } from '@/utils/bigmath';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { stakePowercardCompound } from '@/wallet/actions/treasury/powercard/stake';
 import { estimateStakePowercardCompound } from '@/wallet/actions/treasury/powercard/stakeEstimate';
 
@@ -82,6 +83,7 @@ export default Vue.extend({
     SecondaryPage,
     LoaderForm
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       txStep: undefined as LoaderStep | undefined,

--- a/src/components/treasury/treasury-powercard-manage.vue
+++ b/src/components/treasury/treasury-powercard-manage.vue
@@ -66,6 +66,7 @@ import {
   MAX_ACTIVE_TIME,
   MAX_COOLDOWN_TIME
 } from '@/services/chain/treasury/powercard';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { unstakePowercardCompound } from '@/wallet/actions/treasury/powercard/unstake';
 import { estimateUnstakePowercardCompound } from '@/wallet/actions/treasury/powercard/unstakeEstimate';
 
@@ -89,6 +90,7 @@ export default Vue.extend({
     SecondaryPage,
     LoaderForm
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       actionError: undefined as string | undefined,

--- a/src/store/modules/account/actions/gas.ts
+++ b/src/store/modules/account/actions/gas.ts
@@ -8,25 +8,18 @@ import { getGasPrices } from '@/wallet/gas';
 
 const GAS_UPDATE_INTERVAL = 60000; // 60s
 const GAS_INITIAL_DELAY = 500; // 500ms to reduce the chance to reach the  rate limit of etherscan in case of page reload
-let isOverrunning = false;
 
 export default {
   startGasListening({ commit, state }, caller: string): void {
-    commit('pushCaller', caller);
+    commit('pushGasListenerCaller', caller);
 
     if (state.gasUpdating) {
-      // the process is already running or some other caller already requested
-      // gas listening. There is no need to change things
       return;
     }
 
     commit('setGasUpdating', true);
 
-    if (isOverrunning) {
-      // if the cycle is still in interval
-      // then as state.gasUpdating is set
-      // new cycles will keep going
-      // so there is no need to change things
+    if (state.gasUpdaterHandle !== undefined) {
       return;
     }
 
@@ -40,25 +33,25 @@ export default {
         Sentry.captureException(err);
       } finally {
         if (state.gasUpdating) {
-          setTimeout(updateGasFunc, GAS_UPDATE_INTERVAL);
+          commit(
+            'setGasUpdaterHandle',
+            window.setTimeout(updateGasFunc, GAS_UPDATE_INTERVAL)
+          );
         } else {
-          // if there is no need to perform another cycle
-          // we stop overrunning and finish here
-          isOverrunning = false;
+          commit('clearGasUpdaterHandle');
         }
       }
     };
 
-    isOverrunning = true;
-    setTimeout(updateGasFunc, GAS_INITIAL_DELAY);
+    commit(
+      'setGasUpdaterHandle',
+      window.setTimeout(updateGasFunc, GAS_INITIAL_DELAY)
+    );
   },
   stopGasListening({ commit, state }, caller): void {
-    commit('popCaller', caller);
+    commit('popGasListenerCaller', caller);
 
-    if (state.gasUpdaterCallers.length === 0) {
-      // if there is no listeners left
-      // then we just shut down the process here
-      // and let it overrun if needed
+    if (state.gasUpdaterCallers.length === 0 && state.gasUpdating) {
       commit('setGasUpdating', false);
     }
   }

--- a/src/store/modules/account/actions/gas.ts
+++ b/src/store/modules/account/actions/gas.ts
@@ -11,9 +11,13 @@ const GAS_INITIAL_DELAY = 500; // 500ms to reduce the chance to reach the  rate 
 
 export default {
   startGasListening({ commit, state }, caller: string): void {
-    console.debug('[GAS] started gas listener for', caller);
-    commit('setGasUpdating', true);
     commit('pushCaller', caller);
+
+    if (state.gasUpdating) {
+      return;
+    }
+
+    commit('setGasUpdating', true);
 
     const updateGasFunc = async () => {
       try {
@@ -33,8 +37,8 @@ export default {
     setTimeout(updateGasFunc, GAS_INITIAL_DELAY);
   },
   stopGasListening({ commit, state }, caller): void {
-    console.debug('[GAS] stopped gas listener for', caller);
     commit('popCaller', caller);
+
     if (state.gasUpdaterCallers.length === 0) {
       commit('setGasUpdating', false);
     }

--- a/src/store/modules/account/actions/gas.ts
+++ b/src/store/modules/account/actions/gas.ts
@@ -8,16 +8,27 @@ import { getGasPrices } from '@/wallet/gas';
 
 const GAS_UPDATE_INTERVAL = 60000; // 60s
 const GAS_INITIAL_DELAY = 500; // 500ms to reduce the chance to reach the  rate limit of etherscan in case of page reload
+let isOverrunning = false;
 
 export default {
   startGasListening({ commit, state }, caller: string): void {
     commit('pushCaller', caller);
 
     if (state.gasUpdating) {
+      // the process is already running or some other caller already requested
+      // gas listening. There is no need to change things
       return;
     }
 
     commit('setGasUpdating', true);
+
+    if (isOverrunning) {
+      // if the cycle is still in interval
+      // then as state.gasUpdating is set
+      // new cycles will keep going
+      // so there is no need to change things
+      return;
+    }
 
     const updateGasFunc = async () => {
       try {
@@ -30,16 +41,24 @@ export default {
       } finally {
         if (state.gasUpdating) {
           setTimeout(updateGasFunc, GAS_UPDATE_INTERVAL);
+        } else {
+          // if there is no need to perform another cycle
+          // we stop overrunning and finish here
+          isOverrunning = false;
         }
       }
     };
 
+    isOverrunning = true;
     setTimeout(updateGasFunc, GAS_INITIAL_DELAY);
   },
   stopGasListening({ commit, state }, caller): void {
     commit('popCaller', caller);
 
     if (state.gasUpdaterCallers.length === 0) {
+      // if there is no listeners left
+      // then we just shut down the process here
+      // and let it overrun if needed
       commit('setGasUpdating', false);
     }
   }

--- a/src/store/modules/account/actions/gas.ts
+++ b/src/store/modules/account/actions/gas.ts
@@ -10,8 +10,10 @@ const GAS_UPDATE_INTERVAL = 60000; // 60s
 const GAS_INITIAL_DELAY = 500; // 500ms to reduce the chance to reach the  rate limit of etherscan in case of page reload
 
 export default {
-  startGasListening({ commit, state }): void {
+  startGasListening({ commit, state }, caller: string): void {
+    console.debug('[GAS] started gas listener for', caller);
     commit('setGasUpdating', true);
+    commit('pushCaller', caller);
 
     const updateGasFunc = async () => {
       try {
@@ -30,7 +32,11 @@ export default {
 
     setTimeout(updateGasFunc, GAS_INITIAL_DELAY);
   },
-  stopGasListening({ commit }): void {
-    commit('setGasUpdating', false);
+  stopGasListening({ commit, state }, caller): void {
+    console.debug('[GAS] stopped gas listener for', caller);
+    commit('popCaller', caller);
+    if (state.gasUpdaterCallers.length === 0) {
+      commit('setGasUpdating', false);
+    }
   }
 } as ActionTree<AccountStoreState, RootStoreState>;

--- a/src/store/modules/account/actions/wallet.ts
+++ b/src/store/modules/account/actions/wallet.ts
@@ -181,7 +181,6 @@ export default {
       } as RefreshWalletPayload);
 
       console.log('Starting gas listening...');
-      await dispatch('startGasListening');
     } catch (err) {
       console.log("can't init the wallet");
       console.log(err);

--- a/src/store/modules/account/actions/wallet.ts
+++ b/src/store/modules/account/actions/wallet.ts
@@ -175,6 +175,7 @@ export default {
         pureProvider: payload.provider
       } as ProviderData);
 
+      commit('clearGasUpdaterHandle');
       await dispatch('refreshWallet', {
         injected: payload.injected,
         init: true

--- a/src/store/modules/account/actions/wallet.ts
+++ b/src/store/modules/account/actions/wallet.ts
@@ -179,8 +179,6 @@ export default {
         injected: payload.injected,
         init: true
       } as RefreshWalletPayload);
-
-      console.log('Starting gas listening...');
     } catch (err) {
       console.log("can't init the wallet");
       console.log(err);

--- a/src/store/modules/account/index.ts
+++ b/src/store/modules/account/index.ts
@@ -43,6 +43,7 @@ export default {
 
     gasPrices: undefined,
     gasUpdating: false,
+    gasUpdaterHandle: undefined,
     gasUpdaterCallers: [],
 
     nativeCurrency: 'usd',

--- a/src/store/modules/account/index.ts
+++ b/src/store/modules/account/index.ts
@@ -43,6 +43,7 @@ export default {
 
     gasPrices: undefined,
     gasUpdating: false,
+    gasUpdaterCallers: [],
 
     nativeCurrency: 'usd',
 

--- a/src/store/modules/account/mutations/wallet.ts
+++ b/src/store/modules/account/mutations/wallet.ts
@@ -156,24 +156,12 @@ export default {
   popCaller(state, caller: string): void {
     const idx = state.gasUpdaterCallers.lastIndexOf(caller);
     if (idx < 0) {
-      console.debug(
-        '[GAS] tried to pop caller',
-        caller,
-        'none found in',
-        state.gasUpdaterCallers
-      );
       return;
     }
 
     const newGasUpdaterCallers = [...state.gasUpdaterCallers];
     newGasUpdaterCallers.splice(idx, 1);
     state.gasUpdaterCallers = newGasUpdaterCallers;
-    console.debug(
-      '[GAS] tried to pop caller',
-      caller,
-      'succeeded',
-      newGasUpdaterCallers
-    );
   },
   setAvatars(state, avatars: Array<Avatar>): void {
     state.avatars = avatars;

--- a/src/store/modules/account/mutations/wallet.ts
+++ b/src/store/modules/account/mutations/wallet.ts
@@ -149,10 +149,17 @@ export default {
   setGasUpdating(state, val: boolean): void {
     state.gasUpdating = val;
   },
-  pushCaller(state, caller: string): void {
+  setGasUpdaterHandle(state, handle: number): void {
+    state.gasUpdaterHandle = handle;
+  },
+  clearGasUpdaterHandle(state): void {
+    window.clearTimeout(state.gasUpdaterHandle);
+    state.gasUpdaterHandle = undefined;
+  },
+  pushGasListenerCaller(state, caller: string): void {
     state.gasUpdaterCallers = state.gasUpdaterCallers.concat(caller);
   },
-  popCaller(state, caller: string): void {
+  popGasListenerCaller(state, caller: string): void {
     const idx = state.gasUpdaterCallers.lastIndexOf(caller);
     if (idx < 0) {
       return;

--- a/src/store/modules/account/mutations/wallet.ts
+++ b/src/store/modules/account/mutations/wallet.ts
@@ -151,7 +151,6 @@ export default {
   },
   pushCaller(state, caller: string): void {
     state.gasUpdaterCallers = state.gasUpdaterCallers.concat(caller);
-    console.debug('[GAS] pushed caller', caller);
   },
   popCaller(state, caller: string): void {
     const idx = state.gasUpdaterCallers.lastIndexOf(caller);

--- a/src/store/modules/account/mutations/wallet.ts
+++ b/src/store/modules/account/mutations/wallet.ts
@@ -149,6 +149,32 @@ export default {
   setGasUpdating(state, val: boolean): void {
     state.gasUpdating = val;
   },
+  pushCaller(state, caller: string): void {
+    state.gasUpdaterCallers = state.gasUpdaterCallers.concat(caller);
+    console.debug('[GAS] pushed caller', caller);
+  },
+  popCaller(state, caller: string): void {
+    const idx = state.gasUpdaterCallers.lastIndexOf(caller);
+    if (idx < 0) {
+      console.debug(
+        '[GAS] tried to pop caller',
+        caller,
+        'none found in',
+        state.gasUpdaterCallers
+      );
+      return;
+    }
+
+    const newGasUpdaterCallers = [...state.gasUpdaterCallers];
+    newGasUpdaterCallers.splice(idx, 1);
+    state.gasUpdaterCallers = newGasUpdaterCallers;
+    console.debug(
+      '[GAS] tried to pop caller',
+      caller,
+      'succeeded',
+      newGasUpdaterCallers
+    );
+  },
   setAvatars(state, avatars: Array<Avatar>): void {
     state.avatars = avatars;
   },

--- a/src/store/modules/account/types.ts
+++ b/src/store/modules/account/types.ts
@@ -80,6 +80,7 @@ export type AccountStoreState = {
 
   gasPrices: GasData | undefined;
   gasUpdating: boolean;
+  gasUpdaterHandle: number | undefined;
   gasUpdaterCallers: Array<string>;
   isDebitCardSectionVisible: boolean;
   isDepositCardSectionVisible: boolean;

--- a/src/store/modules/account/types.ts
+++ b/src/store/modules/account/types.ts
@@ -80,6 +80,7 @@ export type AccountStoreState = {
 
   gasPrices: GasData | undefined;
   gasUpdating: boolean;
+  gasUpdaterCallers: Array<string>;
   isDebitCardSectionVisible: boolean;
   isDepositCardSectionVisible: boolean;
 

--- a/src/store/modules/modals/actions.ts
+++ b/src/store/modules/modals/actions.ts
@@ -18,10 +18,14 @@ type SetVisibilityArgs<K extends TModalKey> = {
 
 export default {
   async setIsDisplayed(
-    { state, commit },
+    { state, commit, dispatch },
     { id, value, payload }: SetVisibilityArgs<TModalKey>
   ): Promise<TModalReturn<TModalKey>> {
     if (!value) {
+      if (state.state[id].needGasListener) {
+        await dispatch('account/stopGasListening', id, { root: true });
+      }
+
       const stackPosition = state.stack.findIndex(
         (stackEntry) => stackEntry === id
       );
@@ -75,6 +79,10 @@ export default {
       // remove modal from stack
       commit('popStack');
       return;
+    }
+
+    if (state.state[id].needGasListener) {
+      await dispatch('account/startGasListening', id, { root: true });
     }
 
     if (state.stack.length > 0) {

--- a/src/store/modules/modals/index.ts
+++ b/src/store/modules/modals/index.ts
@@ -18,7 +18,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: true
       },
       [Modal.SavingsWithdraw]: {
         isDisplayed: false,
@@ -26,7 +27,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: true
       },
       [Modal.SearchToken]: {
         isDisplayed: false,
@@ -34,7 +36,8 @@ export default {
         stackDepth: -1,
         waitForResult: true,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: false
       },
       [Modal.Swap]: {
         isDisplayed: false,
@@ -42,7 +45,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: true
       },
       [Modal.Transaction]: {
         isDisplayed: false,
@@ -50,7 +54,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: false
       },
       [Modal.TreasuryIncreaseBoost]: {
         isDisplayed: false,
@@ -58,7 +63,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: true
       },
       [Modal.TreasuryDecreaseBoost]: {
         isDisplayed: false,
@@ -66,7 +72,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: true
       },
       [Modal.TreasuryClaimAndBurn]: {
         isDisplayed: false,
@@ -74,7 +81,8 @@ export default {
         stackDepth: -1,
         waitForResult: false,
         payload: undefined,
-        resolver: undefined
+        resolver: undefined,
+        needGasListener: true
       }
     },
     stack: []

--- a/src/store/modules/modals/types.ts
+++ b/src/store/modules/modals/types.ts
@@ -70,6 +70,7 @@ export type ModalState<K extends TModalKey> = {
   isVisible: boolean;
   stackDepth: number;
   waitForResult: boolean;
+  needGasListener: boolean;
 
   payload?: TModalPayload<K>;
   resolver?: (args: TModalReturn<K>) => Promise<TModalReturn<K>>;

--- a/src/utils/gas-listener-mixin.ts
+++ b/src/utils/gas-listener-mixin.ts
@@ -1,0 +1,26 @@
+import Vue from 'vue';
+import { mapActions } from 'vuex';
+
+export const GasListenerMixin = Vue.extend({
+  data() {
+    return {
+      gasListenerId: 'no_name_provided'
+    };
+  },
+  async beforeMount() {
+    if (this.$options?.name !== undefined) {
+      this.gasListenerId = this.$options.name;
+    }
+
+    await this.startGasListening(this.gasListenerId);
+  },
+  async beforeDestroy() {
+    await this.stopGasListening(this.gasListenerId);
+  },
+  methods: {
+    ...mapActions('account', {
+      startGasListening: 'startGasListening',
+      stopGasListening: 'stopGasListening'
+    })
+  }
+});

--- a/src/views/savings/savings-deposit-wrapper.vue
+++ b/src/views/savings/savings-deposit-wrapper.vue
@@ -91,6 +91,7 @@ import {
   toWei
 } from '@/utils/bigmath';
 import { formatToNative } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { depositCompound } from '@/wallet/actions/savings/deposit/deposit';
 import { estimateDepositCompound } from '@/wallet/actions/savings/deposit/depositEstimate';
 import {
@@ -126,6 +127,7 @@ export default Vue.extend({
     LoaderForm,
     SecondaryPage
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       //current

--- a/src/views/savings/savings-withdraw-wrapper.vue
+++ b/src/views/savings/savings-withdraw-wrapper.vue
@@ -51,6 +51,7 @@ import * as Sentry from '@sentry/vue';
 import { TransferData } from '@/services/0x/api';
 import { divide, isZero, lessThan, multiply } from '@/utils/bigmath';
 import { formatToNative } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { withdrawCompound } from '@/wallet/actions/savings/withdraw/withdraw';
 import {
   CompoundEstimateResponse,
@@ -83,6 +84,7 @@ export default Vue.extend({
     LoaderForm,
     SecondaryPage
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       //current

--- a/src/views/treasury/treasury-claim-and-burn-wrapper.vue
+++ b/src/views/treasury/treasury-claim-and-burn-wrapper.vue
@@ -82,6 +82,7 @@ import {
   multiply
 } from '@/utils/bigmath';
 import { formatToNative } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { claimAndBurnCompound } from '@/wallet/actions/treasury/claimAndBurn/claimAndBurn';
 import { estimateClaimAndBurnCompound } from '@/wallet/actions/treasury/claimAndBurn/claimAndBurnEstimate';
 import { CompoundEstimateResponse } from '@/wallet/actions/types';
@@ -115,6 +116,7 @@ export default Vue.extend({
     LoaderForm,
     SecondaryPage
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       //current

--- a/src/views/treasury/treasury-decrease-wrapper.vue
+++ b/src/views/treasury/treasury-decrease-wrapper.vue
@@ -70,6 +70,7 @@ import {
   sub
 } from '@/utils/bigmath';
 import { formatToDecimals } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { withdrawCompound } from '@/wallet/actions/treasury/withdraw/withdraw';
 import { estimateWithdrawCompound } from '@/wallet/actions/treasury/withdraw/withdrawEstimate';
 import { CompoundEstimateResponse } from '@/wallet/actions/types';
@@ -105,6 +106,7 @@ export default Vue.extend({
     ReviewForm,
     SecondaryPage
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       //current

--- a/src/views/treasury/treasury-increase-wrapper.vue
+++ b/src/views/treasury/treasury-increase-wrapper.vue
@@ -71,6 +71,7 @@ import {
   sub
 } from '@/utils/bigmath';
 import { formatToDecimals } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 import { calcTransactionFastNativePrice } from '@/wallet/actions/subsidized';
 import { depositCompound } from '@/wallet/actions/treasury/deposit/deposit';
 import { estimateDepositCompound } from '@/wallet/actions/treasury/deposit/depositEstimate';
@@ -105,6 +106,7 @@ export default Vue.extend({
     LoaderForm,
     SecondaryPage
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       //prepare-form


### PR DESCRIPTION
**Context**
* Currently the gas listener runs on every view even if this is not necessary (this consumes API rates at about 4 requests/min)

**Approach explanation**
* Every view/component needing to listen to gas info is registered in a stack-like manner
* Once at least 1 listener is active, following listeners simply share the Vuex state. If no active listeners found then new gas listener loop is started
* Modals trigger start/stop on `setIsDisplayed(true/false)` events accordingly, considering the prototype flag `needGasListener`
* Views/other components use new `GasListenerMixin` to bind start/stop actions to their lifecycle hooks
* As the process should be wise about API quotes, an overrun logic is applied (similar to generator rotor overrun) -- the process still takes its place and stops after next data fetch period if `state.gasUpdating` became false

**Possible drawbacks**
* There is a possibility that we trigger new cycle right at (after) the moment process stops and additional quota spending will occur. This drawback allows us to avoid additional variable / check to tell if the process should be stopped but is in an overrun. Although it is possible, this is not a major problem -- the very next update cycle will recover the state properly

**What was done**
* Added throttle/listener wrapper to the start/stop actions
* Added gas listener requests to the modals (based on their properties)
* Added lifecycle mixin `GasListenerMixin`
* Used `GasListenerMixin` on components that clearly require gas info to be up-to-date