### PR TITLE
[Chore] Cleanup feature-flags

### DIFF
--- a/src/components/sections/header-balance-section/header-balance.vue
+++ b/src/components/sections/header-balance-section/header-balance.vue
@@ -42,11 +42,7 @@
         navigate-to-name="card"
         :text="$t('card.lblCard')"
       />
-      <nav-bar-item
-        v-if="isFeatureEnabled('isMoreEnabled')"
-        navigate-to-name="home-more"
-        :text="$t('lblMore')"
-      />
+      <nav-bar-item navigate-to-name="home-more" :text="$t('lblMore')" />
     </nav-bar>
   </section>
 </template>

--- a/src/components/sections/header-balance-section/header-balance.vue
+++ b/src/components/sections/header-balance-section/header-balance.vue
@@ -33,11 +33,6 @@
         :text="$t('treasury.lblSmartTreasury')"
       />
       <nav-bar-item
-        v-if="isFeatureEnabled('isGovernanceEnabled')"
-        navigate-to-name="governance-view-all"
-        :text="$t('governance.lblGovernance')"
-      />
-      <nav-bar-item
         v-if="isFeatureEnabled('isBondsEnabled')"
         navigate-to-name="bonds"
         :text="$t('bonds.lblBonds')"

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -610,48 +610,8 @@ const messages: VueI18n.LocaleMessageObject = {
     },
     lblIpfsLink: 'Your registered vote',
     txtIpfsLink: 'Link'
-  }
-};
-
-if (isFeatureEnabled('isReleaseRadarEnabled')) {
-  messages.radar = {
-    lblTokenOfTheDay: 'Token of the day',
-    liveUpdates: {
-      lblLiveUpdates: 'Live updates',
-      lblTopMovers: 'Top Movers',
-      lblTopLosers: 'Top losers',
-      lblNewTokens: 'New tokens',
-      lblDeFi: 'DeFi',
-      lblStablecoins: 'Stablecoins'
-    },
-    lblPersonalLists: 'Personal Lists',
-    lblCuratedLists: 'Curated Lists',
-    lblRune: 'RUNE',
-    txtRuneAlt: '{name} coin icon',
-    txtRadar: {
-      runeDescription:
-        'RUNE is a native token of THORChain — a cross-network AMM exchange. ' +
-        'THORChain allows for native swaps between various blockchains e.g. a ' +
-        'native swap between ETH and BTC.'
-    },
-    btnGet: {
-      simple: 'Get'
-    },
-    btnSearch: {
-      emoji: '🔍'
-    }
-  };
-}
-
-if (isFeatureEnabled('isBondsEnabled')) {
-  messages.bonds = {
-    icon: '🏦',
-    lblBonds: 'Bonds'
-  };
-}
-
-if (isFeatureEnabled('isNftDropsEnabled')) {
-  messages.NFTs = {
+  },
+  NFTs: {
     lblDiceProject: 'Dice Project',
     lblVaults: 'Vaults',
     lblUnexpectedMove: 'Unexpected Move',
@@ -802,6 +762,43 @@ if (isFeatureEnabled('isNftDropsEnabled')) {
         }
       }
     }
+  }
+};
+
+if (isFeatureEnabled('isReleaseRadarEnabled')) {
+  messages.radar = {
+    lblTokenOfTheDay: 'Token of the day',
+    liveUpdates: {
+      lblLiveUpdates: 'Live updates',
+      lblTopMovers: 'Top Movers',
+      lblTopLosers: 'Top losers',
+      lblNewTokens: 'New tokens',
+      lblDeFi: 'DeFi',
+      lblStablecoins: 'Stablecoins'
+    },
+    lblPersonalLists: 'Personal Lists',
+    lblCuratedLists: 'Curated Lists',
+    lblRune: 'RUNE',
+    txtRuneAlt: '{name} coin icon',
+    txtRadar: {
+      runeDescription:
+        'RUNE is a native token of THORChain — a cross-network AMM exchange. ' +
+        'THORChain allows for native swaps between various blockchains e.g. a ' +
+        'native swap between ETH and BTC.'
+    },
+    btnGet: {
+      simple: 'Get'
+    },
+    btnSearch: {
+      emoji: '🔍'
+    }
+  };
+}
+
+if (isFeatureEnabled('isBondsEnabled')) {
+  messages.bonds = {
+    icon: '🏦',
+    lblBonds: 'Bonds'
   };
 }
 

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -477,48 +477,8 @@ const messages: VueI18n.LocaleMessageObject = {
     }
   },
   lblOhSnap: 'Oh, snap!',
-  txtCouldNotFindToken: 'We couldn’t find this token anywhere'
-};
-
-if (isFeatureEnabled('isReleaseRadarEnabled')) {
-  messages.radar = {
-    lblTokenOfTheDay: 'Token of the day',
-    liveUpdates: {
-      lblLiveUpdates: 'Live updates',
-      lblTopMovers: 'Top Movers',
-      lblTopLosers: 'Top losers',
-      lblNewTokens: 'New tokens',
-      lblDeFi: 'DeFi',
-      lblStablecoins: 'Stablecoins'
-    },
-    lblPersonalLists: 'Personal Lists',
-    lblCuratedLists: 'Curated Lists',
-    lblRune: 'RUNE',
-    txtRuneAlt: '{name} coin icon',
-    txtRadar: {
-      runeDescription:
-        'RUNE is a native token of THORChain — a cross-network AMM exchange. ' +
-        'THORChain allows for native swaps between various blockchains e.g. a ' +
-        'native swap between ETH and BTC.'
-    },
-    btnGet: {
-      simple: 'Get'
-    },
-    btnSearch: {
-      emoji: '🔍'
-    }
-  };
-}
-
-if (isFeatureEnabled('isBondsEnabled')) {
-  messages.bonds = {
-    icon: '🏦',
-    lblBonds: 'Bonds'
-  };
-}
-
-if (isFeatureEnabled('isGovernanceEnabled')) {
-  messages.governance = {
+  txtCouldNotFindToken: 'We couldn’t find this token anywhere',
+  governance: {
     lblGovernance: 'Governance',
     lblGetInvolved: 'Get involved',
     lblGovernancePrefix: 'Governance',
@@ -650,6 +610,43 @@ if (isFeatureEnabled('isGovernanceEnabled')) {
     },
     lblIpfsLink: 'Your registered vote',
     txtIpfsLink: 'Link'
+  }
+};
+
+if (isFeatureEnabled('isReleaseRadarEnabled')) {
+  messages.radar = {
+    lblTokenOfTheDay: 'Token of the day',
+    liveUpdates: {
+      lblLiveUpdates: 'Live updates',
+      lblTopMovers: 'Top Movers',
+      lblTopLosers: 'Top losers',
+      lblNewTokens: 'New tokens',
+      lblDeFi: 'DeFi',
+      lblStablecoins: 'Stablecoins'
+    },
+    lblPersonalLists: 'Personal Lists',
+    lblCuratedLists: 'Curated Lists',
+    lblRune: 'RUNE',
+    txtRuneAlt: '{name} coin icon',
+    txtRadar: {
+      runeDescription:
+        'RUNE is a native token of THORChain — a cross-network AMM exchange. ' +
+        'THORChain allows for native swaps between various blockchains e.g. a ' +
+        'native swap between ETH and BTC.'
+    },
+    btnGet: {
+      simple: 'Get'
+    },
+    btnSearch: {
+      emoji: '🔍'
+    }
+  };
+}
+
+if (isFeatureEnabled('isBondsEnabled')) {
+  messages.bonds = {
+    icon: '🏦',
+    lblBonds: 'Bonds'
   };
 }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -233,8 +233,7 @@ const routes: Array<RouteConfig> = [
             /* webpackChunkName: "governance" */ '@/views/governance/governance-view-all.vue'
           )
       }
-    ],
-    beforeEnter: checkFeatureFlag('isGovernanceEnabled')
+    ]
   },
   {
     path: '/nibble-shop',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -322,8 +322,7 @@ const routes: Array<RouteConfig> = [
             /* webpackChunkName: "nft-drops" */ '@/views/nft/nft-view-dice.vue'
           )
       }
-    ],
-    beforeEnter: checkFeatureFlag('isNftDropsEnabled')
+    ]
   },
   {
     path: '/transactions/:txHash',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -353,27 +353,25 @@ const router = new VueRouter({
   routes
 });
 
-if (isFeatureEnabled('isNavigationFallbackEnabled')) {
-  // detect initial navigation
-  let isInitialNavigation = false;
-  router.beforeEach((to, from, next) => {
-    isInitialNavigation = from === VueRouter.START_LOCATION;
-    next();
-  });
+// detect initial navigation
+let isInitialNavigation = false;
+router.beforeEach((to, from, next) => {
+  isInitialNavigation = from === VueRouter.START_LOCATION;
+  next();
+});
 
-  // save original router.back() implementation bound to the initial router
-  const originalRouterBack = router.back.bind(router);
+// save original router.back() implementation bound to the initial router
+const originalRouterBack = router.back.bind(router);
 
-  // substitute with the custom implementation
-  router.back = async (): Promise<void> => {
-    if (isInitialNavigation && router.currentRoute.name !== 'home') {
-      await router.replace({ name: 'home' });
-      return;
-    }
+// substitute with the custom implementation
+router.back = async (): Promise<void> => {
+  if (isInitialNavigation && router.currentRoute.name !== 'home') {
+    await router.replace({ name: 'home' });
+    return;
+  }
 
-    originalRouterBack();
-  };
-}
+  originalRouterBack();
+};
 
 router.beforeEach((to, from, next) => {
   const { lang } = to.params;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,8 +18,7 @@ const routes: Array<RouteConfig> = [
     path: '/more',
     name: 'home-more',
     component: () =>
-      import(/* webpackChunkName: "home" */ '@/views/home-more.vue'),
-    beforeEnter: checkFeatureFlag('isMoreEnabled')
+      import(/* webpackChunkName: "home" */ '@/views/home-more.vue')
   },
   {
     path: '/connect-wallet',

--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -3,7 +3,6 @@ export interface Globals {
   isSwapPassportEnabled: boolean;
   isReleaseRadarEnabled: boolean;
   isDebitCardEnabled: boolean;
-  isGovernanceEnabled: boolean;
   isGovernanceMarkdownEnabled: boolean;
   isBondsEnabled: boolean;
   isCardEnabled: boolean;
@@ -21,7 +20,6 @@ const values: Globals = {
   isSwapPassportEnabled: false,
   isReleaseRadarEnabled: false,
   isDebitCardEnabled: false,
-  isGovernanceEnabled: true,
   isGovernanceMarkdownEnabled: false,
   isBondsEnabled: false,
   isCardEnabled: false,

--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -8,7 +8,6 @@ export interface Globals {
   isCardEnabled: boolean;
   isMoreEnabled: boolean;
   isNibbleShopEnabled: boolean;
-  isNftDropsEnabled: boolean;
   isIntercomEnabled: boolean;
   isSavingsMonthlyChartEnabled: boolean;
   isTreasuryMonthlyChartEnabled: boolean;
@@ -25,7 +24,6 @@ const values: Globals = {
   isCardEnabled: false,
   isMoreEnabled: true,
   isNibbleShopEnabled: false,
-  isNftDropsEnabled: true,
   isIntercomEnabled: false,
   isSavingsMonthlyChartEnabled: false,
   isTreasuryMonthlyChartEnabled: false,

--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -11,7 +11,6 @@ export interface Globals {
   isIntercomEnabled: boolean;
   isSavingsMonthlyChartEnabled: boolean;
   isTreasuryMonthlyChartEnabled: boolean;
-  isNavigationFallbackEnabled: boolean;
 }
 
 const values: Globals = {
@@ -26,8 +25,7 @@ const values: Globals = {
   isNibbleShopEnabled: false,
   isIntercomEnabled: false,
   isSavingsMonthlyChartEnabled: false,
-  isTreasuryMonthlyChartEnabled: false,
-  isNavigationFallbackEnabled: true
+  isTreasuryMonthlyChartEnabled: false
 };
 
 export const isFeatureEnabled = <T extends keyof Globals>(key: T): boolean =>

--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -1,7 +1,6 @@
 export interface Globals {
   isSavingsOverviewSomeFieldsEnabled: boolean;
   isSwapPassportEnabled: boolean;
-  isVaultsEnabled: boolean;
   isReleaseRadarEnabled: boolean;
   isDebitCardEnabled: boolean;
   isGovernanceEnabled: boolean;
@@ -20,7 +19,6 @@ export interface Globals {
 const values: Globals = {
   isSavingsOverviewSomeFieldsEnabled: false,
   isSwapPassportEnabled: false,
-  isVaultsEnabled: true,
   isReleaseRadarEnabled: false,
   isDebitCardEnabled: false,
   isGovernanceEnabled: true,

--- a/src/settings/globals.ts
+++ b/src/settings/globals.ts
@@ -6,7 +6,6 @@ export interface Globals {
   isGovernanceMarkdownEnabled: boolean;
   isBondsEnabled: boolean;
   isCardEnabled: boolean;
-  isMoreEnabled: boolean;
   isNibbleShopEnabled: boolean;
   isIntercomEnabled: boolean;
   isSavingsMonthlyChartEnabled: boolean;
@@ -21,7 +20,6 @@ const values: Globals = {
   isGovernanceMarkdownEnabled: false,
   isBondsEnabled: false,
   isCardEnabled: false,
-  isMoreEnabled: true,
   isNibbleShopEnabled: false,
   isIntercomEnabled: false,
   isSavingsMonthlyChartEnabled: false,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,7 +25,8 @@ const store = new Vuex.Store<RootStoreState>({
   mutations: mutations,
   modules: {
     account,
-    modals
+    modals,
+    governance
   }
 });
 
@@ -39,10 +40,6 @@ if (isFeatureEnabled('isNftDropsEnabled')) {
 
 if (isFeatureEnabled('isReleaseRadarEnabled')) {
   store.registerModule('radar', radar);
-}
-
-if (isFeatureEnabled('isGovernanceEnabled')) {
-  store.registerModule('governance', governance);
 }
 
 export default store;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,16 +26,13 @@ const store = new Vuex.Store<RootStoreState>({
   modules: {
     account,
     modals,
-    governance
+    governance,
+    nft
   }
 });
 
 if (isFeatureEnabled('isNibbleShopEnabled')) {
   store.registerModule('shop', shop);
-}
-
-if (isFeatureEnabled('isNftDropsEnabled')) {
-  store.registerModule('nft', nft);
 }
 
 if (isFeatureEnabled('isReleaseRadarEnabled')) {

--- a/src/store/modules/nft/actions/init.ts
+++ b/src/store/modules/nft/actions/init.ts
@@ -203,10 +203,8 @@ export default {
               }
             ]
           }
-        }
-      ];
-      if (isFeatureEnabled('isVaultsEnabled')) {
-        nftAssets.splice(0, 0, {
+        },
+        {
           name: 'Vaults',
           description: rootState.i18n?.t(
             'NFTs.txtNFTs.vaults.description'
@@ -250,8 +248,8 @@ export default {
               }
             ]
           }
-        });
-      }
+        }
+      ];
 
       if (isFeatureEnabled('isSwapPassportEnabled')) {
         nftAssets.push({
@@ -329,17 +327,11 @@ export default {
       rootState!.account!.provider!.web3
     );
 
-    let vaultsDataPromise: Promise<VaultsData | undefined> =
-      Promise.resolve(undefined);
-    if (isFeatureEnabled('isVaultsEnabled')) {
-      vaultsDataPromise = vaultsDataPromise.then(() =>
-        getVaultsData(
-          rootState!.account!.currentAddress!,
-          rootState!.account!.networkInfo!.network,
-          rootState!.account!.provider!.web3
-        )
-      );
-    }
+    const vaultsDataPromise = getVaultsData(
+      rootState!.account!.currentAddress!,
+      rootState!.account!.networkInfo!.network,
+      rootState!.account!.provider!.web3
+    );
 
     const diceDataPromise = getDiceData(
       rootState!.account!.currentAddress!,

--- a/src/views/home-more.vue
+++ b/src/views/home-more.vue
@@ -6,7 +6,7 @@
     @back="handleClose"
     @close="handleClose"
   >
-    <governance-section v-if="isFeatureEnabled('isGovernanceEnabled')" />
+    <governance-section />
     <nibble-shop-section v-if="isFeatureEnabled('isNibbleShopEnabled')" />
     <nft-drops-section v-if="isFeatureEnabled('isNftDropsEnabled')" />
   </content-wrapper>

--- a/src/views/home-more.vue
+++ b/src/views/home-more.vue
@@ -8,7 +8,7 @@
   >
     <governance-section />
     <nibble-shop-section v-if="isFeatureEnabled('isNibbleShopEnabled')" />
-    <nft-drops-section v-if="isFeatureEnabled('isNftDropsEnabled')" />
+    <nft-drops-section />
   </content-wrapper>
 </template>
 


### PR DESCRIPTION
Context
* An app contains unused feature flags which are unlikely to be toggled in the future

What was done
* Removed flags:
  * isVaultsEnabled -- Vaults NFT
  * isGovernanceEnabled -- Governance module (live & active)
  * isNftDropsEnabled -- NFT Drops module (live & active, non-separable from current app state)
  * isNavigationFallbackEnabled -- Navigation fallback preventing app from going to blank page after first render (live & active)
  * isMoreEnabled -- More page (live & active, non-separable from current app state)
* Merged localizations where it was needed