### PR TITLE
[FIX] Sentry release issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
             curl -sL https://sentry.io/get-cli/ | bash
             export SENTRY_RELEASE=$(sentry-cli releases propose-version)
             sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-            sentry-cli releases set-commits $SENTRY_RELEASE --auto
+            sentry-cli releases set-commits $SENTRY_RELEASE --auto --ignore-missing
             sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps dist/www/js/*
             sentry-cli releases finalize $SENTRY_RELEASE
             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
@@ -105,7 +105,7 @@ jobs:
             curl -sL https://sentry.io/get-cli/ | bash
             export SENTRY_RELEASE=$(sentry-cli releases propose-version)
             sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-            sentry-cli releases set-commits $SENTRY_RELEASE --auto
+            sentry-cli releases set-commits $SENTRY_RELEASE --auto --ignore-missing
             sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps dist/www/js/*
             sentry-cli releases finalize $SENTRY_RELEASE
             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT


### PR DESCRIPTION
There is an issue https://github.com/getsentry/sentry-cli/issues/792
The fast way to solve it - add `--ignore-missing` flag