### PR TITLE
[Feature] Debit Card not supported country message

### DIFF
--- a/src/components/debit-card/manage/debit-card-manage-set-email.vue
+++ b/src/components/debit-card/manage/debit-card-manage-set-email.vue
@@ -135,7 +135,6 @@ export default Vue.extend({
             this.errorText = this.$t(
               `provider.errors.${error.code}`
             ).toString();
-            this.scrollButtonIntoView();
             return;
           }
         }
@@ -148,7 +147,6 @@ export default Vue.extend({
             this.errorText = this.$t(
               `debitCard.errors.${error.message}`
             ) as string;
-            this.scrollButtonIntoView();
             return;
           }
 
@@ -156,14 +154,13 @@ export default Vue.extend({
             this.errorText = this.$t(
               `debitCard.errors.${error.message}`
             ) as string;
-            this.scrollButtonIntoView();
             return;
           }
         }
 
         this.errorText = this.$t('debitCard.errors.default') as string;
-        this.scrollButtonIntoView();
       } finally {
+        this.scrollButtonIntoView();
         this.isLoading = false;
       }
     },

--- a/src/components/debit-card/manage/debit-card-manage-validate-phone.vue
+++ b/src/components/debit-card/manage/debit-card-manage-validate-phone.vue
@@ -191,7 +191,6 @@ export default Vue.extend({
             this.errorText = this.$t(
               `provider.errors.${error.code}`
             ).toString();
-            this.scrollButtonIntoView();
             return;
           }
         }
@@ -204,7 +203,6 @@ export default Vue.extend({
             this.errorText = this.$t(
               `debitCard.errors.${error.message}`
             ) as string;
-            this.scrollButtonIntoView();
             return;
           }
 
@@ -212,14 +210,13 @@ export default Vue.extend({
             this.errorText = this.$t(
               `debitCard.errors.${error.message}`
             ) as string;
-            this.scrollButtonIntoView();
             return;
           }
         }
 
         this.errorText = this.$t('debitCard.errors.default') as string;
-        this.scrollButtonIntoView();
       } finally {
+        this.scrollButtonIntoView();
         this.isLoading = false;
       }
     },

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -1,4 +1,4 @@
-import VueI18n, { LocaleMessage } from 'vue-i18n';
+import VueI18n from 'vue-i18n';
 
 import { isFeatureEnabled } from '@/settings';
 
@@ -269,7 +269,11 @@ const messages: VueI18n.LocaleMessageObject = {
       alreadyRegistered: 'This email is already used',
       badPhoneSyntax:
         'Phone number should be valid (e.g. @:debitCard.txtYourPhoneNumberPlaceholder)',
-      incorrectCode: 'Security code is invalid. Please try again'
+      incorrectCode: 'Security code is invalid. Please try again',
+      notSupportedCountry:
+        'Sorry, but {country}{flag} is not supported yet. We are looking forward to expanding as soon as possible.',
+      notSupportedCountryFallback:
+        'Sorry but the country associated with your phone number is not supported yet. We are looking forward to expanding as soon as possible.'
     }
   },
   savingsDepositCard: {

--- a/src/services/etherscan/gas.ts
+++ b/src/services/etherscan/gas.ts
@@ -130,7 +130,7 @@ export const getGasSpeedWithoutErr = async (
 ): Promise<string> => {
   const gasPriceInWei = Web3.utils.toWei(gasPriceInGwei, 'Gwei');
   const res = await getGasSpeed(gasPriceInWei, network);
-  if (isError<string, GetGasErrors>(res)) {
+  if (isError<string, GetGasErrors, void>(res)) {
     console.log(res.error);
     return '0';
   }

--- a/src/services/mover/debit-card/index.ts
+++ b/src/services/mover/debit-card/index.ts
@@ -1,4 +1,4 @@
-export { DebitCardApiError } from './types';
+export { DebitCardApiError, DebitCardNotSupportedCountryError } from './types';
 
 export {
   getCardInfo,

--- a/src/services/mover/debit-card/types.ts
+++ b/src/services/mover/debit-card/types.ts
@@ -1,9 +1,15 @@
-import { MoverResponse } from '../responses';
-export class DebitCardApiError extends Error {
-  constructor(readonly message: string, readonly shortMessage?: string) {
+import { MoverResponse, MoverResponseExtended } from '../responses';
+export class DebitCardApiError<T> extends Error {
+  constructor(
+    readonly message: string,
+    readonly shortMessage?: string,
+    readonly additionalPayload?: T
+  ) {
     super(message);
   }
 }
+
+export class DebitCardNotSupportedCountryError extends DebitCardApiError<NotSupportedCountryErrorPayload> {}
 
 export type CardStatus =
   | 'NOT_REGISTERED' // user did not filled personal data form yet
@@ -71,7 +77,14 @@ export type OrderCardRequestPayload = Request<{
   info: OrderCardPayload;
   sig: string;
 }>;
-export type OrderCardResponsePayload = MoverResponse<BaseResponse>;
+export type NotSupportedCountryErrorPayload = {
+  country: string;
+  countryName: string;
+};
+export type OrderCardResponsePayload = MoverResponseExtended<
+  BaseResponse,
+  NotSupportedCountryErrorPayload
+>;
 export type OrderCardReturn = BaseReturn;
 
 export type ValidatePhoneNumberRequestPayload = Request<{ code: string }>;

--- a/src/services/mover/governance/service.ts
+++ b/src/services/mover/governance/service.ts
@@ -117,7 +117,7 @@ export const getCommunityVotingPower = async (
 
     return { isError: false, result: response.payload };
   } catch (error) {
-    const axiosError = error as AxiosError<MoverApiErrorResponse>;
+    const axiosError = error as AxiosError<MoverApiErrorResponse<unknown>>;
     if (axiosError.response !== undefined) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
@@ -161,7 +161,7 @@ export const getVotingPower = async (
 
     return { isError: false, result: response.payload };
   } catch (error) {
-    const axiosError = error as AxiosError<MoverApiErrorResponse>;
+    const axiosError = error as AxiosError<MoverApiErrorResponse<unknown>>;
     if (axiosError.response !== undefined) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx

--- a/src/services/mover/responses.ts
+++ b/src/services/mover/responses.ts
@@ -2,7 +2,7 @@ export type SuccessfulResponse<T> = {
   status: 'ok';
   payload: T;
 };
-export type ErrorResponse = {
+export type ErrorResponse<E> = {
   status: 'error';
 
   // short service explanation
@@ -10,6 +10,12 @@ export type ErrorResponse = {
 
   // user-friendly error message which can be displayed
   error: string;
+
+  payload: E;
 };
 
-export type MoverResponse<T> = SuccessfulResponse<T> | ErrorResponse;
+export type MoverResponse<T> = SuccessfulResponse<T> | ErrorResponse<void>;
+
+export type MoverResponseExtended<T, E> =
+  | SuccessfulResponse<T>
+  | ErrorResponse<E>;

--- a/src/services/responses.ts
+++ b/src/services/responses.ts
@@ -1,9 +1,12 @@
-export type Result<T, E extends string> = ErrorResult<E> | SuccessResult<T>;
+export type Result<T, E extends string, P = void> =
+  | ErrorResult<E, P>
+  | SuccessResult<T>;
 
-export type ErrorResult<E extends string> = {
+export type ErrorResult<E extends string, P = void> = {
   isError: true;
   error: E;
   shortError?: E;
+  payload?: P;
 };
 
 export type SuccessResult<T> = {
@@ -11,14 +14,14 @@ export type SuccessResult<T> = {
   result: T;
 };
 
-export const isError = <T, E extends string>(
-  res: Result<T, E>
-): res is ErrorResult<E> => {
+export const isError = <T, E extends string, P>(
+  res: Result<T, E, P>
+): res is ErrorResult<E, P> => {
   return res.isError;
 };
 
-export const isSuccess = <T, E extends string>(
-  res: Result<T, E>
+export const isSuccess = <T, E extends string, P>(
+  res: Result<T, E, P>
 ): res is SuccessResult<T> => {
   return !res.isError;
 };

--- a/src/services/zerion/transactions.ts
+++ b/src/services/zerion/transactions.ts
@@ -95,7 +95,7 @@ export const mapZerionTxns = async (
     const moverTypesDataRes = await getMoverTransactionsTypes(
       data.payload.transactions.map((t) => t.hash)
     );
-    if (isError<TransactionMoveTypeData[], string>(moverTypesDataRes)) {
+    if (isError<TransactionMoveTypeData[], string, void>(moverTypesDataRes)) {
       console.error(
         `Error from mover transaction service: ${moverTypesDataRes.error}`
       );

--- a/src/store/modules/debit-card/actions.ts
+++ b/src/store/modules/debit-card/actions.ts
@@ -9,6 +9,7 @@ import {
   BaseReturn,
   changePhoneNumber,
   DebitCardApiError,
+  DebitCardNotSupportedCountryError,
   getCardInfo,
   orderCard,
   sendEmailHash,
@@ -461,9 +462,25 @@ export default {
           if (res.shortError === 'PHONE_SYNTAX') {
             throw new DebitCardApiError('badPhoneSyntax');
           }
+
+          if (res.shortError === 'UNSUPPORTED_COUNTRY') {
+            if (res.payload) {
+              throw new DebitCardNotSupportedCountryError(
+                res.error,
+                res.shortError,
+                res.payload
+              );
+            }
+
+            // handle missing payload gracefully (component will render itself as intended)
+            throw new DebitCardNotSupportedCountryError(
+              res.error,
+              res.shortError
+            );
+          }
         }
 
-        throw new DebitCardApiError(res.error, res.shortError);
+        throw new DebitCardApiError(res.error, res.shortError, res.payload);
       }
 
       commit('setIsLoading', true);
@@ -550,6 +567,22 @@ export default {
         if (res.shortError !== undefined) {
           if (res.shortError === 'PHONE_SYNTAX') {
             throw new DebitCardApiError('badPhoneSyntax');
+          }
+
+          if (res.shortError === 'UNSUPPORTED_COUNTRY') {
+            if (res.payload) {
+              throw new DebitCardNotSupportedCountryError(
+                res.error,
+                res.shortError,
+                res.payload
+              );
+            }
+
+            // handle missing payload gracefully (component will render itself as intended)
+            throw new DebitCardNotSupportedCountryError(
+              res.error,
+              res.shortError
+            );
           }
         }
 

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,0 +1,41 @@
+const supportsFlagEmoji = (): boolean => {
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.height = 10;
+    canvas.width = canvas.height * 2;
+    const ctx = canvas.getContext('2d');
+    if (ctx == null) {
+      return false;
+    }
+    ctx.font = canvas.height + 'px Arial';
+    ctx.fillText('🇬🇧', 0, canvas.height);
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    let i = 0;
+    while (i < data.length) {
+      if (data[i] !== data[i + 1] || data[i] !== data[i + 2]) return true;
+      i += 4;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+const getFlagEmoji = (countryCode: string): string => {
+  const codePoints = countryCode
+    .toUpperCase()
+    .split('')
+    .map((char) => 127397 + char.charCodeAt(0));
+  return String.fromCodePoint(...codePoints);
+};
+
+export const mapCountryCodeToEmoji = (
+  countryCode: string,
+  withSpace = false
+): string => {
+  if (!supportsFlagEmoji()) {
+    return '';
+  }
+
+  return ` ${getFlagEmoji(countryCode)}`;
+};

--- a/src/wallet/gas.ts
+++ b/src/wallet/gas.ts
@@ -14,7 +14,7 @@ export const getGasPrices = async (
 
   const res = await getGasPricesFromEtherscan(network);
 
-  if (isError<GasData, GetGasErrors>(res)) {
+  if (isError<GasData, GetGasErrors, void>(res)) {
     console.error(
       `Can't load gas prices from Etherscan: ${res.error}, trying another source...`
     );
@@ -27,7 +27,7 @@ export const getGasPrices = async (
     }
   }
 
-  if (isSuccess<GasData, GetGasErrors>(res)) {
+  if (isSuccess<GasData, GetGasErrors, void>(res)) {
     return res.result;
   }
 


### PR DESCRIPTION
Context
* Before this PR there was a case when not supported country and generic order API error were non-distinguishable

What was done
* Refactored generic data types to have optional typed payload
* Added special classes/types/cases for such errors
* Added new messages
* Refactored related code to use these data types as well