### PR TITLE
[Fix] Card active status

### DIFF
--- a/src/services/mover/debit-card/types.ts
+++ b/src/services/mover/debit-card/types.ts
@@ -12,13 +12,13 @@ export class DebitCardApiError<T> extends Error {
 export class DebitCardNotSupportedCountryError extends DebitCardApiError<NotSupportedCountryErrorPayload> {}
 
 export type CardStatus =
-  | 'NOT_REGISTERED' // user did not filled personal data form yet
+  | 'NOT_REGISTERED' // user did not fill personal data form yet
   | 'PHONE_VERIFICATION_PENDING' // account is signed up, SMS sent to phone number provided
   | 'KYC_WAITING' // user verified phone, but not passed KYC yet
   | 'KYC_PENDING' // user has passed KYC, it is being verified (wait)
   | 'CARD_ORDER_PENDING' // user has verified phone and passed KYC, we would order card;
   | 'CARD_SHIPPED' // the card is ordered, to be shipped
-  | 'ACTIVE'; // the card is active
+  | 'CARD_ACTIVE'; // the card is active
 
 export type EventHistoryItemMinimal = {
   timestamp: number;

--- a/src/store/modules/debit-card/types.ts
+++ b/src/store/modules/debit-card/types.ts
@@ -92,7 +92,7 @@ export const mapServiceState = (
     case 'CARD_ORDER_PENDING':
     case 'CARD_SHIPPED':
       return { cardState: 'pending', orderState: undefined };
-    case 'ACTIVE':
+    case 'CARD_ACTIVE':
     default:
       return { cardState: 'active', orderState: undefined };
   }


### PR DESCRIPTION
Context
* There is a new status on the API side (`CARD_ACTIVE`)
* The previous one was used in mapper -> inaccurate result of mapping

What was done
* Updated `ACTIVE` to `CARD_ACTIVE`
* Updated status mapper
* Fixed typo