### PR TITLE
[Fix] Debit Card mapper

### DIFF
--- a/src/store/modules/debit-card/actions.ts
+++ b/src/store/modules/debit-card/actions.ts
@@ -49,7 +49,7 @@ export default {
       info.statusHistory?.map(mapServiceHistoryItem) ?? []
     );
 
-    if (info.cardInfo !== undefined) {
+    if (info.cardInfo?.status === 'CARD_ACTIVE') {
       commit('setCardInfo', mapServiceCardInfo(info.cardInfo));
       // an actual status will be represented here once the card is in active status
       const mappedState = mapServiceState(info.cardInfo.status);


### PR DESCRIPTION
Context
* The response payload occasionally contains the key with zero-valued entries
* The application code contains an implicit check of the final card status (CARD_ACTIVE)

What was done
* Replaced implicit check (`info.cardInfo !== undefined`) with an explicit one (`info.cardInfo?.cardStatus === 'CARD_ACTIVE'`)