### PR TITLE
[Fix] Debit card mapper (part 2)

### DIFF
--- a/src/services/mover/debit-card/types.ts
+++ b/src/services/mover/debit-card/types.ts
@@ -18,7 +18,8 @@ export type CardStatus =
   | 'KYC_PENDING' // user has passed KYC, it is being verified (wait)
   | 'CARD_ORDER_PENDING' // user has verified phone and passed KYC, we would order card;
   | 'CARD_SHIPPED' // the card is ordered, to be shipped
-  | 'CARD_ACTIVE'; // the card is active
+  | 'CARD_ACTIVE' // the card is active (outer status)
+  | 'ACTIVE'; // the card is active (inner status)
 
 export type EventHistoryItemMinimal = {
   timestamp: number;

--- a/src/store/modules/debit-card/actions.ts
+++ b/src/store/modules/debit-card/actions.ts
@@ -49,7 +49,7 @@ export default {
       info.statusHistory?.map(mapServiceHistoryItem) ?? []
     );
 
-    if (info.cardInfo?.status === 'CARD_ACTIVE') {
+    if (info.status === 'CARD_ACTIVE' && info.cardInfo !== undefined) {
       commit('setCardInfo', mapServiceCardInfo(info.cardInfo));
       // an actual status will be represented here once the card is in active status
       const mappedState = mapServiceState(info.cardInfo.status);

--- a/src/store/modules/debit-card/types.ts
+++ b/src/store/modules/debit-card/types.ts
@@ -93,6 +93,7 @@ export const mapServiceState = (
     case 'CARD_SHIPPED':
       return { cardState: 'pending', orderState: undefined };
     case 'CARD_ACTIVE':
+    case 'ACTIVE':
     default:
       return { cardState: 'active', orderState: undefined };
   }


### PR DESCRIPTION
Context
* `info.cardInfo.status` is used instead of `info.status`
* `ACTIVE` status (which is inner structure status) is missing from the type declaration

What was done
* Fixed the issue