### PR TITLE
[Fix] Add address argument to persist functions

### DIFF
--- a/src/settings/persist/utils.ts
+++ b/src/settings/persist/utils.ts
@@ -53,7 +53,7 @@ const isMoverEntryType = (
   }
 };
 
-export const removeExpiredItemsFromLocalStorage = (): void => {
+export const removeExpiredPersistItemsFromLocalStorage = (): void => {
   getLocalStorageKeys().forEach((key) => {
     try {
       const persistedValue = window.localStorage.getItem(key);

--- a/src/settings/persist/utils.ts
+++ b/src/settings/persist/utils.ts
@@ -23,7 +23,7 @@ const getLocalStorageKeys = (): Array<string> => {
   return Object.keys(window.localStorage);
 };
 
-export const removeAccountBoundPersistItemsFromStore = (
+export const removeAccountBoundPersistItemsFromLocalStorage = (
   currentAddress: string
 ): void => {
   const keysWithPostfix = getLocalStorageKeys().filter((key) =>
@@ -53,7 +53,7 @@ const isMoverEntryType = (
   }
 };
 
-export const removeExpiredItemsFromStorage = (): void => {
+export const removeExpiredItemsFromLocalStorage = (): void => {
   getLocalStorageKeys().forEach((key) => {
     try {
       const persistedValue = window.localStorage.getItem(key);

--- a/src/store/modules/account/actions.ts
+++ b/src/store/modules/account/actions.ts
@@ -23,7 +23,7 @@ import {
 } from '@/settings';
 import {
   removeAccountBoundPersistItemsFromLocalStorage,
-  removeExpiredItemsFromLocalStorage
+  removeExpiredPersistItemsFromLocalStorage
 } from '@/settings/persist/utils';
 import { ActionFuncs } from '@/store/types';
 import { Network } from '@/utils/networkTypes';
@@ -330,7 +330,7 @@ const actions: ActionFuncs<
       Sentry.setTag('crypto_person_address', state.currentAddress);
 
       if (payload.init) {
-        removeExpiredItemsFromLocalStorage();
+        removeExpiredPersistItemsFromLocalStorage();
 
         bootIntercomSession(state.currentAddress, {
           network: state.networkInfo.network

--- a/src/store/modules/account/actions.ts
+++ b/src/store/modules/account/actions.ts
@@ -21,6 +21,10 @@ import {
   setAvatarToPersist,
   setIsOlympusAvatarKnownToPersist
 } from '@/settings';
+import {
+  removeAccountBoundPersistItemsFromStore,
+  removeExpiredItemsFromStorage
+} from '@/settings/persist/utils';
 import { ActionFuncs } from '@/store/types';
 import { Network } from '@/utils/networkTypes';
 import { getAllTokens } from '@/wallet/allTokens';
@@ -326,6 +330,8 @@ const actions: ActionFuncs<
       Sentry.setTag('crypto_person_address', state.currentAddress);
 
       if (payload.init) {
+        removeExpiredItemsFromStorage();
+
         bootIntercomSession(state.currentAddress, {
           network: state.networkInfo.network
         });
@@ -481,6 +487,10 @@ const actions: ActionFuncs<
     });
   },
   async disconnectWallet({ commit, state }): Promise<void> {
+    if (state.currentAddress) {
+      removeAccountBoundPersistItemsFromStore(state.currentAddress);
+    }
+
     if (state.provider) {
       state.provider.providerBeforeClose();
       if (

--- a/src/store/modules/account/actions.ts
+++ b/src/store/modules/account/actions.ts
@@ -22,8 +22,8 @@ import {
   setIsOlympusAvatarKnownToPersist
 } from '@/settings';
 import {
-  removeAccountBoundPersistItemsFromStore,
-  removeExpiredItemsFromStorage
+  removeAccountBoundPersistItemsFromLocalStorage,
+  removeExpiredItemsFromLocalStorage
 } from '@/settings/persist/utils';
 import { ActionFuncs } from '@/store/types';
 import { Network } from '@/utils/networkTypes';
@@ -330,7 +330,7 @@ const actions: ActionFuncs<
       Sentry.setTag('crypto_person_address', state.currentAddress);
 
       if (payload.init) {
-        removeExpiredItemsFromStorage();
+        removeExpiredItemsFromLocalStorage();
 
         bootIntercomSession(state.currentAddress, {
           network: state.networkInfo.network
@@ -488,7 +488,7 @@ const actions: ActionFuncs<
   },
   async disconnectWallet({ commit, state }): Promise<void> {
     if (state.currentAddress) {
-      removeAccountBoundPersistItemsFromStore(state.currentAddress);
+      removeAccountBoundPersistItemsFromLocalStorage(state.currentAddress);
     }
 
     if (state.provider) {


### PR DESCRIPTION
Context
* All saved info should be bound to the current address
* Saved info will eventually pile up to the QUOTA_LIMIT and break storage

What was done
* Updated all usages of persist functions
* Added two cleaners
  * removeExpiredPersistItemsFromLocalStorage
  * removeAccountBoundPersistItemsFromLocalStorage