### PR TITLE
[Fix] Add missing GasListenerMixin to the views with chain interactions

### DIFF
--- a/src/store/modules/account/actions.ts
+++ b/src/store/modules/account/actions.ts
@@ -110,7 +110,7 @@ const actions: ActionFuncs<
         const resp = await getGasPrices(state.networkInfo?.network);
         commit('setGasPrices', resp);
       } catch (err) {
-        commit('setRefreshEror', err);
+        commit('setRefreshError', err);
         console.log(`Can't get gas prices, err:`, err);
         Sentry.captureException(err);
       } finally {

--- a/src/store/modules/account/mutations.ts
+++ b/src/store/modules/account/mutations.ts
@@ -36,7 +36,7 @@ type Mutations = {
   updateWalletTokens: void;
   removeWalletTokens: void;
   setAllTokens: void;
-  setRefreshEror: void;
+  setRefreshError: void;
   setIsDetecting: void;
   setProvider: void;
   setAccountData: void;
@@ -153,7 +153,7 @@ const mutations: MutationFuncs<Mutations, AccountStoreState> = {
 
     state.tokenInfoMap = aggregateObject;
   },
-  setRefreshEror(state, error): void {
+  setRefreshError(state, error): void {
     state.refreshError = error;
   },
   setIsDetecting(state, isDetecting: boolean): void {

--- a/src/views/nft/nft-view-dice.vue
+++ b/src/views/nft/nft-view-dice.vue
@@ -181,6 +181,7 @@ import { mapActions, mapState } from 'vuex';
 
 import { DiceType } from '@/services/chain';
 import { DicePayload } from '@/store/modules/nft/types';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { AnalyticsList, AnalyticsListItem } from '@/components/analytics-list';
 import {
@@ -205,6 +206,7 @@ export default Vue.extend({
     ActionButton,
     SimpleLoaderModal
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       popoverParentId: 'dice-project-action-buttons',

--- a/src/views/nft/nft-view-moving-with-olympus.vue
+++ b/src/views/nft/nft-view-moving-with-olympus.vue
@@ -93,6 +93,7 @@ import dayjs from 'dayjs';
 
 import { ChangePayload } from '@/store/modules/nft/types';
 import { formatToDecimals } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { AnalyticsList, AnalyticsListItem } from '@/components/analytics-list';
 import { ActionButton } from '@/components/buttons';
@@ -109,6 +110,7 @@ export default Vue.extend({
     AnalyticsListItem,
     SimpleLoaderModal
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       transactionStep: undefined as Step | undefined,

--- a/src/views/nft/nft-view-swap-passport.vue
+++ b/src/views/nft/nft-view-swap-passport.vue
@@ -24,6 +24,7 @@ import Vue from 'vue';
 import { mapState } from 'vuex';
 
 import { NftAssetId } from '@/store/modules/nft/types';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { ContentWrapperTwoSided } from '@/components/layout';
 
@@ -32,6 +33,7 @@ export default Vue.extend({
   components: {
     ContentWrapperTwoSided
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       NftAssetId

--- a/src/views/nft/nft-view-sweet-and-sour.vue
+++ b/src/views/nft/nft-view-sweet-and-sour.vue
@@ -91,6 +91,7 @@ import { mapActions, mapState } from 'vuex';
 import { getSweetAndSourClaimSignature } from '@/services/chain';
 import { ClaimPayload } from '@/store/modules/nft/types';
 import { formatToDecimals } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { AnalyticsList, AnalyticsListItem } from '@/components/analytics-list';
 import { ActionButton } from '@/components/buttons';
@@ -107,6 +108,7 @@ export default Vue.extend({
     ActionButton,
     SimpleLoaderModal
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       transactionStep: undefined as Step | undefined,

--- a/src/views/nft/nft-view-unexpected-move.vue
+++ b/src/views/nft/nft-view-unexpected-move.vue
@@ -120,6 +120,7 @@ import { mapActions, mapState } from 'vuex';
 import { getUnexpectedMoveClaimSignature } from '@/services/chain';
 import { ChangePayload, ClaimPayload } from '@/store/modules/nft/types';
 import { formatToDecimals } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { AnalyticsList, AnalyticsListItem } from '@/components/analytics-list';
 import { ActionButton, EmojiTextButton } from '@/components/buttons';
@@ -137,6 +138,7 @@ export default Vue.extend({
     AnalyticsListItem,
     SimpleLoaderModal
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       transactionStep: undefined as Step | undefined,

--- a/src/views/nft/nft-view-vaults.vue
+++ b/src/views/nft/nft-view-vaults.vue
@@ -86,6 +86,7 @@ import { mapActions, mapState } from 'vuex';
 
 import { ChangePayload } from '@/store/modules/nft/types';
 import { formatToDecimals } from '@/utils/format';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { AnalyticsList, AnalyticsListItem } from '@/components/analytics-list';
 import { ActionButton } from '@/components/buttons';
@@ -102,6 +103,7 @@ export default Vue.extend({
     ActionButton,
     SimpleLoaderModal
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       transactionStep: undefined as Step | undefined,

--- a/src/views/nibble-shop/nibble-shop-view.vue
+++ b/src/views/nibble-shop/nibble-shop-view.vue
@@ -96,6 +96,7 @@ import { Properties } from 'csstype';
 import { ClaimPayload } from '@/store/modules/shop/types';
 import { Asset } from '@/store/modules/shop/types';
 import { fromWei } from '@/utils/bigmath';
+import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
 import { AnalyticsList, AnalyticsListItem } from '@/components/analytics-list';
 import { ActionButton, EmojiTextButton } from '@/components/buttons';
@@ -113,6 +114,7 @@ export default Vue.extend({
     AnalyticsListItem,
     SimpleLoaderModal
   },
+  mixins: [GasListenerMixin],
   data() {
     return {
       transactionStep: undefined as Step | undefined,


### PR DESCRIPTION
Context
* Views under `/nft-drops/view/*` and `/nibble-shop/view/*` were not using gas prices properly due to missing activation triggers under `GasListenerMixin`

What was done
* Added missing GasListenerMixin to the views with chain interactions
* Renamed Vuex mutation to fix the typo `setRefreshEror` -> `setRefreshError`