### PR TITLE
[Fix] Load action calls loop

### DIFF
--- a/src/components/savings/savings-manage.vue
+++ b/src/components/savings/savings-manage.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { mapActions, mapGetters, mapState } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 import dayjs from 'dayjs';
 
@@ -139,11 +139,7 @@ export default Vue.extend({
       return this.colors['product-savings'];
     }
   },
-  mounted() {
-    this.fetchSavingsInfo();
-  },
   methods: {
-    ...mapActions('savings', { fetchSavingsInfo: 'fetchSavingsInfo' }),
     handleItemSelected(item: SavingsMonthBalanceItem): void {
       this.selectedItem = item;
     },

--- a/src/components/treasury/treasury-manage.vue
+++ b/src/components/treasury/treasury-manage.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { mapActions, mapGetters, mapState } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 import dayjs from 'dayjs';
 
@@ -138,11 +138,7 @@ export default Vue.extend({
       return this.colors['product-treasury'];
     }
   },
-  mounted() {
-    this.fetchTreasuryInfo();
-  },
   methods: {
-    ...mapActions('treasury', { fetchTreasuryInfo: 'fetchTreasuryInfo' }),
     handleItemSelected(item: TreasuryMonthBonusesItem): void {
       this.selectedItem = item;
     },

--- a/src/views/savings/savings-global-analytics.vue
+++ b/src/views/savings/savings-global-analytics.vue
@@ -71,7 +71,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { mapActions, mapGetters, mapState } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 import { isFeatureEnabled } from '@/settings';
 import {
@@ -153,11 +153,7 @@ export default Vue.extend({
       return `${getSignIfNeeded(value, '+')}$${value}`;
     }
   },
-  mounted() {
-    this.fetchSavingsInfo();
-  },
   methods: {
-    ...mapActions('savings', { fetchSavingsInfo: 'fetchSavingsInfo' }),
     isFeatureEnabled,
     handleBack(): void {
       this.$router.back();

--- a/src/views/treasury/treasury-global-analytics.vue
+++ b/src/views/treasury/treasury-global-analytics.vue
@@ -79,7 +79,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { mapActions, mapGetters, mapState } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 import {
   formatToDecimals,
@@ -211,11 +211,7 @@ export default Vue.extend({
       return `$${formatToNative(this.treasuryTotalStakedBalanceNative)}`;
     }
   },
-  mounted() {
-    this.fetchTreasuryInfo();
-  },
   methods: {
-    ...mapActions('treasury', { fetchTreasuryInfo: 'fetchTreasuryInfo' }),
     handleBack(): void {
       this.$router.replace({
         name: 'treasury-manage'


### PR DESCRIPTION
Context
* Because of lack of debounce/non-blocking loaders under Savings / Smart Treasury info loaders there is a possible case of looped action calls to the viaMover's view API

What was done
* Removed faulty action calls from Savings & Smart Treasury views