### PR TITLE
[Fix] Change price references (Order of Liberty NFT)

### DIFF
--- a/src/wallet/references/data.ts
+++ b/src/wallet/references/data.ts
@@ -215,11 +215,10 @@ const constants = {
     MASTER_CHEF_POOL_INDEX: 257,
     POWERCARD_RARI_ID: 107150,
     ORDER_OF_LIBERTY_DEFAULT_PRICE: toWei(
-      '0.01',
+      '0.1',
       getBaseAssetData(Network.mainnet).decimals
     ),
     ORDER_OF_LIBERTY_AVAILABLE_PRICES: [
-      toWei('0.1', getBaseAssetData(Network.mainnet).decimals),
       toWei('1', getBaseAssetData(Network.mainnet).decimals),
       toWei('10', getBaseAssetData(Network.mainnet).decimals)
     ]
@@ -231,8 +230,7 @@ const constants = {
     ),
     ORDER_OF_LIBERTY_AVAILABLE_PRICES: [
       toWei('100', getBaseAssetData(Network.fantom).decimals),
-      toWei('1000', getBaseAssetData(Network.fantom).decimals),
-      toWei('10000', getBaseAssetData(Network.fantom).decimals)
+      toWei('1000', getBaseAssetData(Network.fantom).decimals)
     ]
   },
   [Network.polygon]: {
@@ -242,8 +240,7 @@ const constants = {
     ),
     ORDER_OF_LIBERTY_AVAILABLE_PRICES: [
       toWei('100', getBaseAssetData(Network.polygon).decimals),
-      toWei('1000', getBaseAssetData(Network.polygon).decimals),
-      toWei('10000', getBaseAssetData(Network.polygon).decimals)
+      toWei('1000', getBaseAssetData(Network.polygon).decimals)
     ]
   }
 } as ConstantsMap;


### PR DESCRIPTION
Context
* There were some `availablePrices` that are not really available in Contract so this will cause reverts during claim

What was done
* Fixed by removing invalid values