### PR TITLE
[Fix] Add missing require

### DIFF
--- a/src/components/home/home-cards/home-cards-order-of-liberty.vue
+++ b/src/components/home/home-cards/home-cards-order-of-liberty.vue
@@ -36,7 +36,7 @@ export default Vue.extend({
           }
         ],
         webpSources: [
-          { src: '@/assets/images/order-of-liberty/home@1x.webp' },
+          { src: require('@/assets/images/order-of-liberty/home@1x.webp') },
           {
             src: require('@/assets/images/order-of-liberty/home@2x.webp'),
             variant: '2x'


### PR DESCRIPTION
Context
* missing require causing invalid URL to appear in `<source>` tag

What was done
* Added `require()`