### PR TITLE
[Fix] Invalid component render states

### DIFF
--- a/src/views/savings/savings-monthly-statistics.vue
+++ b/src/views/savings/savings-monthly-statistics.vue
@@ -56,15 +56,15 @@ export default Vue.extend({
       const right = this.pageDate.endOf('month').format('MMM DD, YYYY');
 
       return `${left} - ${right}`;
-    }
-  },
-  methods: {
+    },
     isSavingsMonthlyChartEnabled(): boolean {
       return isFeatureEnabled(
         'isSavingsMonthlyChartEnabled',
         this.networkInfo?.network
       );
-    },
+    }
+  },
+  methods: {
     handleBack(): void {
       this.$router.back();
     }

--- a/src/views/treasury/treasury-monthly-statistics.vue
+++ b/src/views/treasury/treasury-monthly-statistics.vue
@@ -52,15 +52,15 @@ export default Vue.extend({
       const right = this.pageDate.endOf('month').format('MMM DD, YYYY');
 
       return `${left} - ${right}`;
-    }
-  },
-  methods: {
+    },
     isTreasuryMonthlyChartEnabled(): boolean {
       return isFeatureEnabled(
         'isTreasuryMonthlyChartEnabled',
         this.networkInfo?.network
       );
-    },
+    }
+  },
+  methods: {
     handleBack(): void {
       this.$router.back();
     }


### PR DESCRIPTION
Context
* Some of the values that are important to the render functions were evaluated as function presence instead of the function result value

What was done
* Moved invalid `is(.*)Enabled` functions to the "computed" section instead of "methods"