### PR TITLE
[Fix] Invalid default error

### DIFF
--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -33,6 +33,9 @@ const messages: VueI18n.LocaleMessageObject = {
   lblCollectibles: 'Collectibles',
   lblNoMoreTransactions: 'No more transactions',
   lblNoMoreTokens: 'No more tokens',
+  errors: {
+    default: 'Oh no. Something went wrong'
+  },
   connect: {
     txtMoverDescription:
       'Mover is a non-custodial service. It means that you need to connect your wallet first, to continue. By connecting your wallet, you agree with the {0}',


### PR DESCRIPTION
Context
* Invalid error messages upon network change under some use-cases

What was done 
* Added missing `errors.default` translation key and value