### PR TITLE
[Fix] Don't load StakingUBT module minimal info in the unsupported networks

### DIFF
--- a/src/components/home/home-navigation-section.vue
+++ b/src/components/home/home-navigation-section.vue
@@ -424,7 +424,9 @@ export default Vue.extend({
       await this.loadEarningsMinimalInfo();
     }
 
-    await this.loadStakingUBTMinimalInfo();
+    if (isFeatureEnabled('isStakingUbtEnabled', this.networkInfo?.network)) {
+      await this.loadStakingUBTMinimalInfo();
+    }
   },
   methods: {
     ...mapActions('modals', {


### PR DESCRIPTION
Context
* The module is being initialized in the unsupported network but shouldn't

What was done
* Added conditional action call