### PR TITLE
[Fix][Feature] Merge received explorer token info with local one

### DIFF
--- a/src/services/explorer.ts
+++ b/src/services/explorer.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/vue';
 
 import { APIKeys } from '@/settings';
 import { Network } from '@/utils/networkTypes';
-import { TokenWithBalance, Transaction } from '@/wallet/types';
+import { Token, TokenWithBalance, Transaction } from '@/wallet/types';
 
 import { MoralisExplorer } from './moralis/explorer';
 import { InitZerionExplorer } from './zerion/explorer';
@@ -29,7 +29,8 @@ export const BuildExplorer = async (
   removeTokens: (tokens: Array<string>) => void,
   setChartData: (chartData: Record<string, Array<[number, number]>>) => void,
   setIsTransactionsListLoaded: (val: boolean) => void,
-  setIsTokensListLoaded: (val: boolean) => void
+  setIsTokensListLoaded: (val: boolean) => void,
+  localTokens: Array<Token>
 ): Promise<Explorer> => {
   const moralisExplorer = new MoralisExplorer(
     accountAddress,
@@ -41,7 +42,8 @@ export const BuildExplorer = async (
     setIsTransactionsListLoaded,
     setTokens,
     setIsTokensListLoaded,
-    setChartData
+    setChartData,
+    localTokens
   );
 
   try {

--- a/src/services/moralis/explorer.ts
+++ b/src/services/moralis/explorer.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/vue';
 import { addABI, decodeMethod } from 'abi-decoder';
 import axios, { AxiosInstance } from 'axios';
 import dayjs from 'dayjs';
+import Web3 from 'web3';
 
 import { getCoingeckoPlatform } from '@/services/coingecko/mapper';
 import { getPriceByAddress, NetworkAlias } from '@/services/coingecko/tokens';
@@ -11,7 +12,7 @@ import store from '@/store/index';
 import { sameAddress } from '@/utils/address';
 import { fromWei } from '@/utils/bigmath';
 import { MAX_ASSET_NAME } from '@/utils/consts';
-import { Network } from '@/utils/networkTypes';
+import { getNetwork, Network } from '@/utils/networkTypes';
 import { getBaseAssetData, getMoveAssetData } from '@/wallet/references/data';
 import {
   Token,
@@ -78,7 +79,8 @@ export class MoralisExplorer implements Explorer {
     private readonly setIsTokensListLoaded: (val: boolean) => void,
     private readonly setChartData: (
       chartData: Record<string, Array<[number, number]>>
-    ) => void
+    ) => void,
+    private readonly localTokens: Array<Token>
   ) {
     this.apiClient = axios.create({
       baseURL: this.apiURL,
@@ -102,9 +104,17 @@ export class MoralisExplorer implements Explorer {
   public async refreshWalletData(): Promise<void> {
     try {
       this.setIsTransactionsListLoaded(false);
-      const tokensWithPricePromise = this.getErc20Tokens().then((tokens) =>
-        this.enrichTokensWithPrices(tokens)
-      );
+      const tokensWithPricePromise = this.getErc20Tokens()
+        .then((tokens) => this.mergeTokensWithLocalTokens(tokens))
+        .then((tokens) => this.mapTokensToChecksumAddresses(tokens))
+        .then((tokens) => this.enrichTokensWithPrices(tokens))
+        .then((tokens) => this.enrichTokensWithNative(tokens))
+        .then((tokensWithNative) => {
+          this.setTokens(tokensWithNative);
+          // set tokens list loaded as early as possible
+          this.setIsTokensListLoaded(true);
+          return tokensWithNative;
+        });
       const erc20TransactionsPromise = this.getErc20Transactions(
         MoralisExplorer.TRANSACTIONS_PER_BATCH,
         0
@@ -120,12 +130,6 @@ export class MoralisExplorer implements Explorer {
           erc20TransactionsPromise,
           nativeTransactionsPromise
         ]);
-
-      this.enrichTokensWithNative(tokensWithPrices).then((tokensWithNative) => {
-        this.setTokens(tokensWithNative);
-        // set tokens list loaded as early as possible
-        this.setIsTokensListLoaded(true);
-      });
 
       const transactions = await this.parseTransactions(
         tokensWithPrices,
@@ -169,14 +173,8 @@ export class MoralisExplorer implements Explorer {
         return false;
       }
 
-      const tokens = store.state?.account?.tokens;
-
-      if (tokens === undefined) {
-        return true;
-      }
-
       const transactions = await this.parseTransactions(
-        tokens,
+        this.localTokens,
         erc20Transactions,
         nativeTransactions
       );
@@ -323,10 +321,7 @@ export class MoralisExplorer implements Explorer {
             assetSymbol = moverData.symbol;
             assetLogo = moverData.iconURL;
           } else {
-            assetName = t.name;
-            if (assetName.length > MAX_ASSET_NAME) {
-              assetName = assetName.substring(0, MAX_ASSET_NAME);
-            }
+            assetName = t.name.slice(0, MAX_ASSET_NAME);
             assetSymbol = t.symbol;
             assetLogo = t.logo ?? '';
           }
@@ -357,6 +352,44 @@ export class MoralisExplorer implements Explorer {
       throw new Error(`Can't get erc20 tokens from Moralis: ${String(e)}`);
     }
   };
+
+  private mergeTokensWithLocalTokens<T extends Token>(
+    tokens: Array<T>
+  ): Array<T> {
+    return tokens.map((token) => {
+      const localToken = this.localTokens.find((localToken) =>
+        sameAddress(localToken.address, token.address)
+      );
+      if (localToken === undefined) {
+        return token;
+      }
+
+      if (token.logo == '') {
+        token.logo = localToken.logo;
+      }
+
+      if (token.priceUSD == '0') {
+        token.priceUSD = localToken.priceUSD;
+      }
+
+      return token;
+    });
+  }
+
+  private mapTokensToChecksumAddresses<T extends Token>(
+    tokens: Array<T>
+  ): Array<T> {
+    const chainId = getNetwork(this.network)?.chainId;
+
+    return tokens.map((token) => {
+      try {
+        token.address = Web3.utils.toChecksumAddress(token.address, chainId);
+        return token;
+      } catch {
+        return token;
+      }
+    });
+  }
 
   private parseTransactions = async (
     walletTokens: Array<Token>,

--- a/src/store/modules/account/actions.ts
+++ b/src/store/modules/account/actions.ts
@@ -413,7 +413,8 @@ const actions: ActionFuncs<
             },
             (val: boolean) => {
               commit('setIsTokensListLoaded', val);
-            }
+            },
+            state.allTokens
           );
 
           explorerInitPromise


### PR DESCRIPTION
Context
* Currently the tokens on L2 networks are not displayed properly in search modal, transaction & wallet list
* Explorers send assets in lowercase format
* `isTokenListLoaded` is actually slowed down by transactions & native transactions query (contrary to what was intended)

What was done
* Added token info merging processor
* Added lowercase-to-checksum token address processor
* Moved process to trigger `isTokenListLoaded` ASAP