### PR TITLE
[Fix] Guard top up route if state is invalid

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -472,20 +472,31 @@ const routes: Array<RouteConfig> = [
           /* webpackChunkName: "debit-card" */ '@/views/debit-card/debit-card-root.vue'
         ),
       children: [
-        {
-          path: 'top-up/step/:step',
-          name: 'debit-card-top-up',
-          component: () =>
-            import(
-              /* webpackChunkName: "debit-card" */ '@/views/debit-card/debit-card-top-up.vue'
-            ),
-          props: (to) => ({
-            step: to.params.step
-          }),
-          beforeEnter: (to, from, next) => {
-            formStepsGuard('debit-card-top-up')(to, from, next);
+        wrapWithMeta(
+          {
+            path: 'top-up/step/:step',
+            name: 'debit-card-top-up',
+            component: () =>
+              import(
+                /* webpackChunkName: "debit-card" */ '@/views/debit-card/debit-card-top-up.vue'
+              ),
+            props: (to) => ({
+              step: to.params.step
+            }),
+            beforeEnter: (to, from, next) => {
+              formStepsGuard('debit-card-top-up')(to, from, next);
+            }
+          },
+          {
+            customCondition: (store?: Store<RootStoreState>): boolean => {
+              if (store === undefined) return false;
+              return (
+                store.state.debitCard?.emailHash !== undefined &&
+                store.state.debitCard?.emailSignature !== undefined
+              );
+            }
           }
-        },
+        ),
         {
           path: 'change-skin',
           name: 'debit-card-change-skin',

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -2,6 +2,7 @@ import { IVueI18n } from 'vue-i18n';
 import { ActionContext, Module, ModuleTree } from 'vuex';
 
 import { Theme } from '@/settings/theme';
+import { DebitCardStoreState } from '@/store/modules/debit-card/types';
 import { GamesStoreState } from '@/store/modules/games/types';
 import { GovernanceStoreState } from '@/store/modules/governance/types';
 import { ModalsStoreState } from '@/store/modules/modals/types';
@@ -32,6 +33,7 @@ export interface RootStoreState {
   earnings?: EarningsStoreState;
   savings?: SavingsStoreState;
   treasury?: TreasuryStoreState;
+  debitCard?: DebitCardStoreState;
   // rootState members end
 }
 


### PR DESCRIPTION
Context
* Previously it was possible to reach /debit-card/top-up/step/prepare route by direct link / manual address input
* This leads to successful transaction execution but if the state is invalid then card API doesn't know where to deposit assets
* Custom condition to guard such cases is required

What was done
* Added custom condition to check whether debit card state is valid or not
* Added the way to merge/ chain custom conditions (it is possible as they are predicates with the same signature) to each other by `appendMeta` helper function