### PR TITLE
[Fix] Estimate transaction gasLimit after approval

### DIFF
--- a/src/components/modals/swap-modal.vue
+++ b/src/components/modals/swap-modal.vue
@@ -135,7 +135,7 @@ import {
   Modal as ModalTypes,
   TModalPayload
 } from '@/store/modules/modals/types';
-import { sameAddress } from '@/utils/address';
+import { isBaseAsset, sameAddress } from '@/utils/address';
 import {
   add,
   convertAmountFromNativeValue,
@@ -951,7 +951,12 @@ export default Vue.extend({
         return;
       }
 
-      if (this.input.asset?.address === 'eth') {
+      if (
+        isBaseAsset(
+          this.input.asset?.address ?? 'missing_address',
+          this.networkInfo?.network
+        )
+      ) {
         this.subsidizedAvailable = false;
         return;
       }

--- a/src/components/modals/swap-modal.vue
+++ b/src/components/modals/swap-modal.vue
@@ -923,25 +923,25 @@ export default Vue.extend({
       outputAsset: Token,
       transferData: TransferData
     ): Promise<void> {
-      const resp = await (
-        this.swapOnChainService as SwapOnChainService
-      ).estimateSwapCompound(
-        inputAsset,
-        outputAsset,
-        inputAmount,
-        transferData
-      );
+      try {
+        const resp = await (
+          this.swapOnChainService as SwapOnChainService
+        ).estimateSwapCompound(
+          inputAsset,
+          outputAsset,
+          inputAmount,
+          transferData
+        );
 
-      if (resp.error) {
-        Sentry.captureException("Can't estimate swap");
+        this.actionGasLimit = resp.actionGasLimit;
+        this.approveGasLimit = resp.approveGasLimit;
+
+        return this.checkSubsidizedAvailability();
+      } catch (error) {
+        console.error('Failed to estimate swap', error);
+        Sentry.captureException(error);
         this.transferError = this.$t('estimationError') as string;
-        return;
       }
-
-      this.actionGasLimit = resp.actionGasLimit;
-      this.approveGasLimit = resp.approveGasLimit;
-
-      this.checkSubsidizedAvailability();
     },
     async checkSubsidizedAvailability(): Promise<void> {
       const gasPrice = this.gasPrices?.FastGas.price ?? '0';

--- a/src/components/treasury/treasury-powercard-empty.vue
+++ b/src/components/treasury/treasury-powercard-empty.vue
@@ -41,9 +41,6 @@
           :text="$t('treasury.powercard.btnActivateThePowercard')"
           @button-click="handleActivateCard"
         />
-        <div v-if="actionError !== undefined" class="action-error-message">
-          {{ actionError }}
-        </div>
       </div>
     </template>
     <loader-form v-else :step="txStep" />
@@ -56,6 +53,7 @@ import { mapActions, mapState } from 'vuex';
 
 import * as Sentry from '@sentry/vue';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { greaterThan } from '@/utils/bigmath';
 import { GasListenerMixin } from '@/utils/gas-listener-mixin';
@@ -85,7 +83,6 @@ export default Vue.extend({
   data() {
     return {
       txStep: undefined as LoaderStep | undefined,
-      actionError: undefined as string | undefined,
       powercard: {
         alt: this.$t('treasury.lblSmartTreasury'),
         src: require('@/assets/images/Powercard@1x.png'),
@@ -135,9 +132,12 @@ export default Vue.extend({
           this.smartTreasuryOnChainService as SmartTreasuryOnChainService
         ).estimateStakePowercardCompound();
       } catch (error) {
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.error('Failed to estimate powercard stake', error);
         Sentry.captureException(error);
-        this.actionError = this.$t('estimationError') as string;
         return;
       }
 

--- a/src/components/treasury/treasury-powercard-empty.vue
+++ b/src/components/treasury/treasury-powercard-empty.vue
@@ -129,12 +129,14 @@ export default Vue.extend({
       updateWalletAfterTxn: 'updateWalletAfterTxn'
     }),
     async handleActivateCard(): Promise<void> {
-      const estimation = await (
-        this.smartTreasuryOnChainService as SmartTreasuryOnChainService
-      ).estimateStakePowercardCompound();
-
-      if (estimation.error) {
-        Sentry.captureException("Can't estimate stake");
+      let estimation;
+      try {
+        estimation = await (
+          this.smartTreasuryOnChainService as SmartTreasuryOnChainService
+        ).estimateStakePowercardCompound();
+      } catch (error) {
+        console.error('Failed to estimate powercard stake', error);
+        Sentry.captureException(error);
         this.actionError = this.$t('estimationError') as string;
         return;
       }

--- a/src/components/treasury/treasury-powercard-manage.vue
+++ b/src/components/treasury/treasury-powercard-manage.vue
@@ -30,9 +30,6 @@
         :text="$t('treasury.powercard.btnRemoveThePowercard')"
         @button-click="handleRemoveCard"
       />
-      <div v-if="actionError !== undefined" class="action-error-message">
-        {{ actionError }}
-      </div>
     </template>
     <loader-form v-else :step="transactionStep" />
   </secondary-page>
@@ -45,6 +42,7 @@ import { mapActions, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import dayjs from 'dayjs';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { GasListenerMixin } from '@/utils/gas-listener-mixin';
 
@@ -75,7 +73,6 @@ export default Vue.extend({
   mixins: [GasListenerMixin],
   data() {
     return {
-      actionError: undefined as string | undefined,
       transactionStep: undefined as LoaderStep | undefined,
       powercard: {
         alt: this.$t('treasury.lblSmartTreasury'),
@@ -160,9 +157,12 @@ export default Vue.extend({
           this.smartTreasuryOnChainService as SmartTreasuryOnChainService
         ).estimateUnstakePowercardCompound();
       } catch (error) {
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.error('Failed to estimate powercard unstake', error);
         Sentry.captureException(error);
-        this.actionError = this.$t('estimationError') as string;
         return;
       }
 

--- a/src/components/treasury/treasury-powercard-manage.vue
+++ b/src/components/treasury/treasury-powercard-manage.vue
@@ -154,12 +154,14 @@ export default Vue.extend({
       });
     },
     async handleRemoveCard(): Promise<void> {
-      const estimation = await (
-        this.smartTreasuryOnChainService as SmartTreasuryOnChainService
-      ).estimateUnstakePowercardCompound();
-
-      if (estimation.error) {
-        Sentry.captureException("Can't estimate swap");
+      let estimation;
+      try {
+        estimation = await (
+          this.smartTreasuryOnChainService as SmartTreasuryOnChainService
+        ).estimateUnstakePowercardCompound();
+      } catch (error) {
+        console.error('Failed to estimate powercard unstake', error);
+        Sentry.captureException(error);
         this.actionError = this.$t('estimationError') as string;
         return;
       }

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -35,7 +35,8 @@ const messages: VueI18n.LocaleMessageObject = {
   lblNoMoreTransactions: 'No more transactions',
   lblNoMoreTokens: 'No more tokens',
   errors: {
-    default: 'Oh no. Something went wrong. (Code: {code})'
+    default: 'Oh no. Something went wrong. (Code: {code})',
+    estimationFailed: 'Failed to estimate transaction'
   },
   connect: {
     txtMoverDescription:

--- a/src/services/v2/on-chain/OnChainService.ts
+++ b/src/services/v2/on-chain/OnChainService.ts
@@ -5,6 +5,7 @@ import { ContractOptions } from 'web3-eth-contract';
 import { AbiItem } from 'web3-utils';
 
 import { NetworkFeatureNotSupportedError } from '@/services/v2';
+import { CompoundEstimateResponse } from '@/services/v2/on-chain/mover';
 import {
   AnyFn,
   CustomContractType,
@@ -209,7 +210,7 @@ export abstract class OnChainService {
         });
 
       if (gasLimit) {
-        return gasLimit.toString();
+        return this.addGasBuffer(gasLimit.toString());
       }
 
       throw new Error(`empty gas limit`);
@@ -352,20 +353,46 @@ export abstract class OnChainService {
     token: SmallTokenInfo,
     contractAddress: string,
     amount: string,
-    action: () => Promise<TransactionReceipt>,
+    action: (newGasLimit: string) => Promise<TransactionReceipt>,
+    estimateHandler: () => Promise<CompoundEstimateResponse>,
     changeStepToProcess: () => Promise<void>,
-    gasLimit: string
+    approveGasLimit: string,
+    actionGasLimit: string
   ): Promise<TransactionReceipt | never> {
     if (await this.needsApprove(token, amount, contractAddress)) {
-      await this.approve(
+      const approveTxReceipt = await this.approve(
         token.address,
         contractAddress,
         changeStepToProcess,
-        gasLimit
+        approveGasLimit
       );
+
+      try {
+        // estimate transaction once more to get exact gas limit
+        // and prevent expensive transactions and out of gas
+        // reverts
+        const estimation = await estimateHandler();
+
+        addSentryBreadcrumb({
+          type: 'debug',
+          message: 'Estimated transaction after approve',
+          data: {
+            oldGasLimit: actionGasLimit,
+            newGasLimit: estimation.actionGasLimit,
+            approveTxHash: approveTxReceipt.transactionHash
+          }
+        });
+
+        actionGasLimit = estimation.actionGasLimit;
+      } catch (error) {
+        throw new OnChainServiceError(
+          'Failed to estimate transaction after approve',
+          { approveTxReceipt }
+        ).wrap(error);
+      }
     }
 
-    return action();
+    return action(actionGasLimit);
   }
 
   protected async executeTransactionWithApproveExt(

--- a/src/services/v2/on-chain/mover/savings/SavingsOnChainService.ts
+++ b/src/services/v2/on-chain/mover/savings/SavingsOnChainService.ts
@@ -100,26 +100,34 @@ export class SavingsOnChainService extends MoverOnChainService {
         inputAsset,
         lookupAddress(this.network, 'HOLY_HAND_ADDRESS'),
         inputAmount,
-        async () => {
+        (newGasLimit) => {
           if (useSubsidized) {
-            return await this.depositSubsidized(
+            return this.depositSubsidized(
               inputAsset,
               inputAmount,
               changeStepToProcess
             );
           }
 
-          return await this.deposit(
+          return this.deposit(
             inputAsset,
             outputAsset,
             inputAmount,
             transferData,
             changeStepToProcess,
-            actionGasLimit
+            newGasLimit
           );
         },
+        () =>
+          this.estimateDepositCompound(
+            inputAsset,
+            outputAsset,
+            inputAmount,
+            transferData
+          ),
         changeStepToProcess,
-        approveGasLimit
+        approveGasLimit,
+        actionGasLimit
       );
     } catch (error) {
       if (error instanceof MoverAPISubsidizedRequestError) {
@@ -135,9 +143,7 @@ export class SavingsOnChainService extends MoverOnChainService {
             outputAsset,
             inputAmount,
             transferData,
-            useSubsidized,
-            actionGasLimit,
-            approveGasLimit
+            useSubsidized
           }
         });
 
@@ -154,7 +160,7 @@ export class SavingsOnChainService extends MoverOnChainService {
           inputAmount,
           transferData,
           useSubsidized,
-          actionGasLimit,
+          actionGasLimit, // may be old, check previous logs to be sure
           approveGasLimit,
           error
         }
@@ -190,11 +196,9 @@ export class SavingsOnChainService extends MoverOnChainService {
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError(
+        'Failed to estimate deposit: failed "needsApprove" check'
+      ).wrap(error);
     }
 
     if (isApproveNeeded) {
@@ -229,11 +233,9 @@ export class SavingsOnChainService extends MoverOnChainService {
           }
         });
 
-        return {
-          error: true,
-          actionGasLimit: '0',
-          approveGasLimit: '0'
-        };
+        throw new OnChainServiceError(
+          'Failed to estimate deposit: failed "approve" estimation'
+        ).wrap(error);
       }
     }
 
@@ -274,24 +276,6 @@ export class SavingsOnChainService extends MoverOnChainService {
           approveGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
-      addSentryBreadcrumb({
-        type: 'error',
-        category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate deposit: empty gas limit',
-        data: {
-          inputAsset,
-          outputAsset,
-          inputAmount,
-          transferData
-        }
-      });
-
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -306,12 +290,24 @@ export class SavingsOnChainService extends MoverOnChainService {
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError('Failed to estimate deposit').wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate deposit: empty gas limit',
+      data: {
+        inputAsset,
+        outputAsset,
+        inputAmount,
+        transferData
+      }
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate deposit: empty gas limit'
+    );
   }
 
   public async withdrawCompound(
@@ -352,7 +348,6 @@ export class SavingsOnChainService extends MoverOnChainService {
             useSubsidized
           }
         });
-
         throw error;
       }
 
@@ -399,18 +394,6 @@ export class SavingsOnChainService extends MoverOnChainService {
           approveGasLimit: '0',
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
-      } else {
-        addSentryBreadcrumb({
-          type: 'error',
-          category: this.sentryCategoryPrefix,
-          message: 'Failed to estimate withdraw: empty gas limit',
-          data: {
-            outputAsset,
-            inputAmount
-          }
-        });
-
-        return { error: true, approveGasLimit: '0', actionGasLimit: '0' };
       }
     } catch (error) {
       addSentryBreadcrumb({
@@ -424,12 +407,22 @@ export class SavingsOnChainService extends MoverOnChainService {
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError('Failed to estimate withdraw').wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate withdraw: empty gas limit',
+      data: {
+        outputAsset,
+        inputAmount
+      }
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate withdraw: empty gas limit'
+    );
   }
 
   protected async deposit(

--- a/src/services/v2/on-chain/mover/smart-treasury/SmartTreasuryOnChainService.ts
+++ b/src/services/v2/on-chain/mover/smart-treasury/SmartTreasuryOnChainService.ts
@@ -896,14 +896,19 @@ export class SmartTreasuryOnChainService
   ): Promise<TransactionReceipt> {
     try {
       return await this.executeTransactionWithApproveExt(
-        async () => this.stakePowercard(actionGasLimit, changeStepToProcess),
-        async () => this.isPowercardApproved(),
-        async () =>
+        (newGasLimit) =>
+          this.stakePowercard(
+            newGasLimit ?? actionGasLimit,
+            changeStepToProcess
+          ),
+        () => this.isPowercardApproved(),
+        () =>
           this.approvePowercard(
             approveGasLimit,
             lookupAddress(this.network, 'POWERCARD_STAKER'),
             changeStepToProcess
-          )
+          ),
+        () => this.estimateStakePowercardCompound()
       );
     } catch (error) {
       addSentryBreadcrumb({
@@ -1019,15 +1024,20 @@ export class SmartTreasuryOnChainService
     changeStepToProcess: () => Promise<void>
   ): Promise<TransactionReceipt> {
     try {
-      return this.executeTransactionWithApproveExt(
-        async () => this.unstakePowercard(actionGasLimit, changeStepToProcess),
-        async () => this.isPowercardApproved(),
-        async () =>
+      return await this.executeTransactionWithApproveExt(
+        (newGasLimit) =>
+          this.unstakePowercard(
+            newGasLimit ?? actionGasLimit,
+            changeStepToProcess
+          ),
+        () => this.isPowercardApproved(),
+        () =>
           this.approvePowercard(
             approveGasLimit,
             lookupAddress(this.network, 'POWERCARD_STAKER'),
             changeStepToProcess
-          )
+          ),
+        () => this.estimateUnstakePowercardCompound()
       );
     } catch (error) {
       addSentryBreadcrumb({

--- a/src/services/v2/on-chain/mover/smart-treasury/SmartTreasuryOnChainService.ts
+++ b/src/services/v2/on-chain/mover/smart-treasury/SmartTreasuryOnChainService.ts
@@ -356,15 +356,17 @@ export class SmartTreasuryOnChainService
         inputAsset,
         lookupAddress(this.network, 'HOLY_HAND_ADDRESS'),
         inputAmount,
-        async () =>
+        (newGasLimit) =>
           this.deposit(
             inputAsset,
             inputAmount,
-            actionGasLimit,
+            newGasLimit,
             changeStepToProcess
           ),
+        () => this.estimateDepositCompound(inputAsset, inputAmount),
         changeStepToProcess,
-        approveGasLimit
+        approveGasLimit,
+        actionGasLimit
       );
     } catch (error) {
       addSentryBreadcrumb({
@@ -406,11 +408,9 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError(
+        'Failed to estimate deposit: failed "needsApprove" check'
+      ).wrap(error);
     }
 
     if (isApproveNeeded) {
@@ -443,11 +443,9 @@ export class SmartTreasuryOnChainService
           }
         });
 
-        return {
-          error: true,
-          actionGasLimit: '0',
-          approveGasLimit: '0'
-        };
+        throw new OnChainServiceError(
+          'Failed to estimate deposit: failed "approve" estimation'
+        ).wrap(error);
       }
     }
 
@@ -497,24 +495,6 @@ export class SmartTreasuryOnChainService
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
-      addSentryBreadcrumb({
-        type: 'error',
-        category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate deposit: empty gas limit',
-        data: {
-          inputAsset,
-          inputAmount,
-          moveAmount,
-          moveEthAmount
-        }
-      });
-
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -528,12 +508,25 @@ export class SmartTreasuryOnChainService
           moveEthAmount
         }
       });
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+
+      throw new OnChainServiceError('Failed to estimate deposit').wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate deposit: empty gas limit',
+      data: {
+        inputAsset,
+        inputAmount,
+        moveAmount,
+        moveEthAmount
+      }
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate deposit: empty gas limit'
+    );
   }
 
   public async withdrawCompound(
@@ -616,24 +609,6 @@ export class SmartTreasuryOnChainService
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
-      addSentryBreadcrumb({
-        type: 'error',
-        category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate withdraw: empty gas limit',
-        data: {
-          outputAsset,
-          inputAmount,
-          moveAmount,
-          moveEthAmount
-        }
-      });
-
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -646,12 +621,25 @@ export class SmartTreasuryOnChainService
           moveEthAmount
         }
       });
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+
+      throw new OnChainServiceError('Failed to estimate withdraw').wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate withdraw: empty gas limit',
+      data: {
+        outputAsset,
+        inputAmount,
+        moveAmount,
+        moveEthAmount
+      }
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate withdraw: empty gas limit'
+    );
   }
 
   public async claimAndBurnCompound(
@@ -666,15 +654,17 @@ export class SmartTreasuryOnChainService
         inputAsset,
         lookupAddress(this.network, 'HOLY_HAND_ADDRESS'),
         inputAmount,
-        async () =>
+        (newGasLimit) =>
           this.claimAndBurn(
             inputAsset,
             inputAmount,
-            actionGasLimit,
+            newGasLimit,
             changeStepToProcess
           ),
+        () => this.estimateClaimAndBurnCompound(inputAsset, inputAmount),
         changeStepToProcess,
-        approveGasLimit
+        approveGasLimit,
+        actionGasLimit
       );
     } catch (error) {
       addSentryBreadcrumb({
@@ -717,11 +707,9 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError(
+        'Failed to estimate claim & burn: failed "needsApprove" check'
+      ).wrap(error);
     }
 
     if (isApproveNeeded) {
@@ -755,11 +743,9 @@ export class SmartTreasuryOnChainService
           }
         });
 
-        return {
-          error: true,
-          actionGasLimit: '0',
-          approveGasLimit: '0'
-        };
+        throw new OnChainServiceError(
+          'Failed to estimate claim & burn: failed "approve" estimation'
+        );
       }
     }
 
@@ -788,18 +774,6 @@ export class SmartTreasuryOnChainService
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
-      addSentryBreadcrumb({
-        type: 'error',
-        category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate claim & burn: empty gas limit',
-        data: {
-          inputAsset,
-          inputAmount
-        }
-      });
-
-      return { error: true, approveGasLimit: '0', actionGasLimit: '0' };
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -812,12 +786,24 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError('Failed to estimate claim & burn').wrap(
+        error
+      );
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate claim & burn: empty gas limit',
+      data: {
+        inputAsset,
+        inputAmount
+      }
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate claim & burn: empty gas limit'
+    );
   }
 
   public async claimAndBurnMOBO(
@@ -880,21 +866,27 @@ export class SmartTreasuryOnChainService
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
+    } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
         category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate claim & burn MOBO: empty gas limit'
+        message: 'Failed to estimate claim & burn MOBO'
       });
 
-      return { error: true, approveGasLimit: '0', actionGasLimit: '0' };
-    } catch (error) {
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError(
+        'Failed to estimate claim & burn MOBO'
+      ).wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate claim & burn MOBO: empty gas limit'
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate claim & burn MOBO: empty gas limit'
+    );
   }
 
   public async stakePowercardCompound(
@@ -942,11 +934,9 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError(
+        'Failed to estimate stake: failed "isPowercardApproved" check'
+      ).wrap(error);
     }
 
     if (!isApproved) {
@@ -976,22 +966,20 @@ export class SmartTreasuryOnChainService
           }
         });
 
-        return {
-          error: true,
-          actionGasLimit: '0',
-          approveGasLimit: '0'
-        };
+        throw new OnChainServiceError(
+          'Failed to estimate stake: failed "approve" estimation'
+        ).wrap(error);
       }
     }
 
-    try {
-      if (this.powercardStakerContract === undefined) {
-        throw new NetworkFeatureNotSupportedError(
-          'Powercard stake',
-          this.network
-        );
-      }
+    if (this.powercardStakerContract === undefined) {
+      throw new NetworkFeatureNotSupportedError(
+        'Powercard stake',
+        this.network
+      );
+    }
 
+    try {
       const gasLimitObj = await this.powercardStakerContract.methods
         .stakePowercard()
         .estimateGas({ from: this.currentAddress });
@@ -1003,18 +991,6 @@ export class SmartTreasuryOnChainService
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
-      addSentryBreadcrumb({
-        type: 'error',
-        category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate stake: empty gas limit'
-      });
-
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -1025,12 +1001,16 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError('Failed to estimate stake').wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate stake: empty gas limit'
+    });
+
+    throw new OnChainServiceError('Failed to estimate stake: empty gas limit');
   }
 
   public async unstakePowercardCompound(
@@ -1078,11 +1058,9 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError(
+        'Failed to estimate unstake: failed "isPowercardApproved" check'
+      ).wrap(error);
     }
 
     if (!isApproved) {
@@ -1112,22 +1090,20 @@ export class SmartTreasuryOnChainService
           }
         });
 
-        return {
-          error: true,
-          actionGasLimit: '0',
-          approveGasLimit: '0'
-        };
+        throw new OnChainServiceError(
+          'Failed to estimate unstake: failed "approve" estimation'
+        ).wrap(error);
       }
     }
 
-    try {
-      if (this.powercardStakerContract === undefined) {
-        throw new NetworkFeatureNotSupportedError(
-          'Powercard unstake',
-          this.network
-        );
-      }
+    if (this.powercardStakerContract === undefined) {
+      throw new NetworkFeatureNotSupportedError(
+        'Powercard unstake',
+        this.network
+      );
+    }
 
+    try {
       const gasLimitObj = await this.powercardStakerContract.methods
         .unstakePowercard()
         .estimateGas({ from: this.currentAddress });
@@ -1139,18 +1115,6 @@ export class SmartTreasuryOnChainService
           actionGasLimit: this.addGasBuffer(gasLimitObj.toString())
         };
       }
-
-      addSentryBreadcrumb({
-        type: 'error',
-        category: this.sentryCategoryPrefix,
-        message: 'Failed to estimate unstake: empty gas limit'
-      });
-
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -1161,12 +1125,18 @@ export class SmartTreasuryOnChainService
         }
       });
 
-      return {
-        error: true,
-        approveGasLimit: '0',
-        actionGasLimit: '0'
-      };
+      throw new OnChainServiceError('Failed to estimate unstake').wrap(error);
     }
+
+    addSentryBreadcrumb({
+      type: 'error',
+      category: this.sentryCategoryPrefix,
+      message: 'Failed to estimate unstake: empty gas limit'
+    });
+
+    throw new OnChainServiceError(
+      'Failed to estimate unstake: empty gas limit'
+    );
   }
 
   public calculateTreasuryBoost(
@@ -1485,8 +1455,6 @@ export class SmartTreasuryOnChainService
       if (gasLimit) {
         return gasLimit.toString();
       }
-
-      throw new Error(`empty gas limit`);
     } catch (error) {
       addSentryBreadcrumb({
         type: 'error',
@@ -1502,5 +1470,9 @@ export class SmartTreasuryOnChainService
         `Failed to estimate approve for powercard`
       ).wrap(error);
     }
+
+    throw new OnChainServiceError(
+      `Failed to estimate approve for powercard: empty gas limit`
+    );
   }
 }

--- a/src/views/debit-card/debit-card-top-up.vue
+++ b/src/views/debit-card/debit-card-top-up.vue
@@ -66,6 +66,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import BigNumber from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import {
   getTransferData,
   TransferData,
@@ -346,7 +347,10 @@ export default Vue.extend({
         this.unwrapGasLimit = gasLimits.unwrapGasLimit;
         this.changeStep('review');
       } catch (error) {
-        this.transferError = this.$t('estimationError') as string;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         addSentryBreadcrumb({
           type: 'error',
           category: 'debit-card.top-up.handleTxReview',

--- a/src/views/debit-card/debit-card-top-up.vue
+++ b/src/views/debit-card/debit-card-top-up.vue
@@ -91,7 +91,6 @@ import { formatToNative } from '@/utils/format';
 import { topUpCompound } from '@/wallet/actions/debit-card/top-up/top-up';
 import { estimateTopUpCompound } from '@/wallet/actions/debit-card/top-up/top-up-estimate';
 import { calcTransactionFastNativePrice } from '@/wallet/actions/subsidized';
-import { CompoundEstimateWithUnwrapResponse } from '@/wallet/actions/types';
 import {
   getALCXAssetData,
   getBTRFLYAssetData,
@@ -101,7 +100,6 @@ import {
   validTopUpAssets
 } from '@/wallet/references/data';
 import {
-  SmallToken,
   SmallTokenInfo,
   SmallTokenInfoWithIcon,
   tokenToSmallTokenInfo,
@@ -333,21 +331,32 @@ export default Vue.extend({
       this.unwrapGasLimit = '0';
       this.isProcessing = true;
       try {
-        const gasLimits = await this.estimateAction(
-          this.inputAmount,
+        const gasLimits = await estimateTopUpCompound(
           this.inputAsset,
-          this.transferData
+          this.usdcAsset,
+          this.inputAmount,
+          this.transferData,
+          this.networkInfo.network,
+          this.provider.web3,
+          this.currentAddress
         );
 
         this.actionGasLimit = gasLimits.actionGasLimit;
         this.approveGasLimit = gasLimits.approveGasLimit;
         this.unwrapGasLimit = gasLimits.unwrapGasLimit;
-        if (!gasLimits.error) {
-          this.changeStep('review');
-        }
-      } catch (err) {
-        Sentry.captureException(err);
-        return;
+        this.changeStep('review');
+      } catch (error) {
+        this.transferError = this.$t('estimationError') as string;
+        addSentryBreadcrumb({
+          type: 'error',
+          category: 'debit-card.top-up.handleTxReview',
+          message: 'Failed to estimate top-up',
+          data: {
+            error
+          }
+        });
+        console.error('Failed to estimate transaction', error);
+        Sentry.captureException(error);
       } finally {
         this.isProcessing = false;
       }
@@ -363,34 +372,6 @@ export default Vue.extend({
         actionGasLimit,
         this.ethPrice
       );
-    },
-    async estimateAction(
-      inputAmount: string,
-      inputAsset: SmallToken,
-      transferData: TransferData | undefined
-    ): Promise<CompoundEstimateWithUnwrapResponse> {
-      const resp = await estimateTopUpCompound(
-        inputAsset,
-        this.usdcAsset,
-        inputAmount,
-        transferData,
-        this.networkInfo.network,
-        this.provider.web3,
-        this.currentAddress
-      );
-      if (resp.error) {
-        this.transferError = this.$t('estimationError') as string;
-        addSentryBreadcrumb({
-          type: 'error',
-          category: 'debit-card.top-up.estimateAction',
-          message: 'failed to estimate top-up',
-          data: {
-            estimateError: resp.error
-          }
-        });
-        Sentry.captureException("can't estimate top-up");
-      }
-      return resp;
     },
     async handleUpdateAmount(val: string): Promise<void> {
       await this.updateAmount(val, this.inputMode);

--- a/src/views/savings/savings-deposit-wrapper.vue
+++ b/src/views/savings/savings-deposit-wrapper.vue
@@ -70,6 +70,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import BigNumber from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { MoverError } from '@/services/v2';
 import { TransferData, ZeroXAPIService } from '@/services/v2/api/0x';
 import { SavingsOnChainService } from '@/services/v2/on-chain/mover/savings';
@@ -336,7 +337,10 @@ export default Vue.extend({
 
         this.step = 'review';
       } catch (error) {
-        this.transferError = this.$t('estimationError') as string;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.warn('Failed to estimate transaction', error);
         Sentry.captureException(error);
         this.isSubsidizedEnabled = false;

--- a/src/views/savings/savings-deposit-wrapper.vue
+++ b/src/views/savings/savings-deposit-wrapper.vue
@@ -74,7 +74,7 @@ import { MoverError } from '@/services/v2';
 import { TransferData, ZeroXAPIService } from '@/services/v2/api/0x';
 import { SavingsOnChainService } from '@/services/v2/on-chain/mover/savings';
 import { Modal as ModalType } from '@/store/modules/modals/types';
-import { sameAddress } from '@/utils/address';
+import { isBaseAsset, sameAddress } from '@/utils/address';
 import {
   add,
   convertAmountFromNativeValue,
@@ -369,7 +369,12 @@ export default Vue.extend({
         return false;
       }
 
-      if (this.inputAsset?.address === 'eth') {
+      if (
+        isBaseAsset(
+          this.inputAsset?.address ?? 'missing_address',
+          this.networkInfo?.network
+        )
+      ) {
         return false;
       }
 

--- a/src/views/savings/savings-withdraw-wrapper.vue
+++ b/src/views/savings/savings-withdraw-wrapper.vue
@@ -47,6 +47,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 
 import * as Sentry from '@sentry/vue';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SavingsOnChainService } from '@/services/v2/on-chain/mover/savings';
 import { isBaseAsset } from '@/utils/address';
 import { divide, isZero, multiply } from '@/utils/bigmath';
@@ -265,6 +266,10 @@ export default Vue.extend({
         this.step = 'review';
       } catch (error) {
         this.isSubsidizedEnabled = false;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.warn('Failed to estimate transaction', error);
         Sentry.captureException(error);
       } finally {

--- a/src/views/savings/savings-withdraw-wrapper.vue
+++ b/src/views/savings/savings-withdraw-wrapper.vue
@@ -48,6 +48,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 
 import { SavingsOnChainService } from '@/services/v2/on-chain/mover/savings';
+import { isBaseAsset } from '@/utils/address';
 import { divide, isZero, multiply } from '@/utils/bigmath';
 import { formatToNative } from '@/utils/format';
 import { GasListenerMixin } from '@/utils/gas-listener-mixin';
@@ -211,6 +212,15 @@ export default Vue.extend({
       const gasPrice = this.gasPrices?.FastGas.price ?? '0';
       const ethPrice = this.ethPrice ?? '0';
       if (isZero(gasPrice) || isZero(actionGasLimit) || isZero(ethPrice)) {
+        return false;
+      }
+
+      if (
+        isBaseAsset(
+          this.inputAsset?.address ?? 'missing_address',
+          this.networkInfo?.network
+        )
+      ) {
         return false;
       }
 

--- a/src/views/staking-ubt/staking-ubt-deposit-wrapper.vue
+++ b/src/views/staking-ubt/staking-ubt-deposit-wrapper.vue
@@ -46,6 +46,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 
 import BigNumber from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { StakingUbtOnChainService } from '@/services/v2/on-chain/mover/staking-ubt';
 import { captureSentryException } from '@/services/v2/utils/sentry';
 import {
@@ -192,7 +193,10 @@ export default Vue.extend({
         this.approveGasLimit = gasLimits.approveGasLimit;
         this.step = 'review';
       } catch (error) {
-        this.error = this.$t('estimationError') as string;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         captureSentryException(error);
       } finally {
         this.isProcessing = false;

--- a/src/views/staking-ubt/staking-ubt-withdraw-wrapper.vue
+++ b/src/views/staking-ubt/staking-ubt-withdraw-wrapper.vue
@@ -46,6 +46,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 
 import BigNumber from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { StakingUbtOnChainService } from '@/services/v2/on-chain/mover/staking-ubt';
 import { captureSentryException } from '@/services/v2/utils/sentry';
 import {
@@ -220,7 +221,10 @@ export default Vue.extend({
         this.actionGasLimit = gasLimits.actionGasLimit;
         this.step = 'review';
       } catch (error) {
-        this.error = this.$t('estimationError') as string;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         captureSentryException(error);
       } finally {
         this.isProcessing = false;

--- a/src/views/treasury/treasury-claim-and-burn-mobo-wrapper.vue
+++ b/src/views/treasury/treasury-claim-and-burn-mobo-wrapper.vue
@@ -68,6 +68,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import BigNumber from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { addSentryBreadcrumb } from '@/services/v2/utils/sentry';
 import { convertNativeAmountFromAmount, notZero } from '@/utils/bigmath';
@@ -248,7 +249,10 @@ export default Vue.extend({
         this.actionGasLimit = gasLimits.actionGasLimit;
         this.step = 'review';
       } catch (error) {
-        this.transferError = this.$t('estimationError') as string;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.error('failed to handle transaction review', error);
         Sentry.captureException(error);
       } finally {

--- a/src/views/treasury/treasury-claim-and-burn-mobo-wrapper.vue
+++ b/src/views/treasury/treasury-claim-and-burn-mobo-wrapper.vue
@@ -68,7 +68,6 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import BigNumber from 'bignumber.js';
 
-import { CompoundEstimateResponse } from '@/services/v2/on-chain/mover';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { addSentryBreadcrumb } from '@/services/v2/utils/sentry';
 import { convertNativeAmountFromAmount, notZero } from '@/utils/bigmath';
@@ -232,16 +231,6 @@ export default Vue.extend({
         });
       }
     },
-    async estimateAction(): Promise<CompoundEstimateResponse> {
-      const estimation = await (
-        this.smartTreasuryOnChainService as SmartTreasuryOnChainService
-      ).estimateClaimAndBurnMOBO();
-      if (estimation.error) {
-        this.transferError = this.$t('estimationError') as string;
-        throw new Error('Failed to estimate action');
-      }
-      return estimation;
-    },
     handleToggleInputMode(): void {
       if (this.inputMode === 'NATIVE') {
         this.inputMode = 'TOKEN';
@@ -252,23 +241,19 @@ export default Vue.extend({
     async handleTxReview(): Promise<void> {
       this.isProcessing = true;
       try {
-        const gasLimits = await this.estimateAction();
+        const gasLimits = await (
+          this.smartTreasuryOnChainService as SmartTreasuryOnChainService
+        ).estimateClaimAndBurnMOBO();
 
         this.actionGasLimit = gasLimits.actionGasLimit;
-
-        console.info(
-          'Claim and burn MOBO action gaslimit:',
-          this.actionGasLimit
-        );
-      } catch (err) {
+        this.step = 'review';
+      } catch (error) {
+        this.transferError = this.$t('estimationError') as string;
+        console.error('failed to handle transaction review', error);
+        Sentry.captureException(error);
+      } finally {
         this.isProcessing = false;
-        console.error('failed to handle transaction review', err);
-        Sentry.captureException("can't estimate claim and burn MOBO for subs");
-        return;
       }
-
-      this.isProcessing = false;
-      this.step = 'review';
     },
     async handleTxStart(): Promise<void> {
       if (this.inputAmount === '') {

--- a/src/views/treasury/treasury-claim-and-burn-wrapper.vue
+++ b/src/views/treasury/treasury-claim-and-burn-wrapper.vue
@@ -69,6 +69,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import BigNumber from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { Modal as ModalType } from '@/store/modules/modals/types';
 import { sameAddress } from '@/utils/address';
@@ -312,7 +313,10 @@ export default Vue.extend({
 
         this.step = 'review';
       } catch (error) {
-        this.transferError = this.$t('estimationError') as string;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.error('failed to handle transaction review', error);
         Sentry.captureException(error);
       } finally {

--- a/src/views/treasury/treasury-decrease-wrapper.vue
+++ b/src/views/treasury/treasury-decrease-wrapper.vue
@@ -57,6 +57,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import * as Sentry from '@sentry/vue';
 import { BigNumber } from 'bignumber.js';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { Modal as ModalType } from '@/store/modules/modals/types';
 import { sameAddress } from '@/utils/address';
@@ -327,6 +328,10 @@ export default Vue.extend({
 
         this.step = 'review';
       } catch (error) {
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.warn('Failed to estimate withdraw', error);
         Sentry.captureException(error);
       } finally {

--- a/src/views/treasury/treasury-increase-wrapper.vue
+++ b/src/views/treasury/treasury-increase-wrapper.vue
@@ -56,7 +56,6 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 
 import * as Sentry from '@sentry/vue';
 
-import { CompoundEstimateResponse } from '@/services/v2/on-chain/mover';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { Modal as ModalType } from '@/store/modules/modals/types';
 import { sameAddress } from '@/utils/address';
@@ -75,11 +74,7 @@ import {
   getMoveAssetData,
   getMoveWethLPAssetData
 } from '@/wallet/references/data';
-import {
-  SmallToken,
-  SmallTokenInfoWithIcon,
-  TokenWithBalance
-} from '@/wallet/types';
+import { SmallTokenInfoWithIcon, TokenWithBalance } from '@/wallet/types';
 
 import {
   InputMode,
@@ -345,18 +340,6 @@ export default Vue.extend({
         this.ethPrice
       );
     },
-    async estimateAction(
-      inputAmount: string,
-      inputAsset: SmallToken
-    ): Promise<CompoundEstimateResponse> {
-      const estimation = await (
-        this.smartTreasuryOnChainService as SmartTreasuryOnChainService
-      ).estimateDepositCompound(inputAsset, inputAmount);
-      if (estimation.error) {
-        throw new Error('Failed to estimate action');
-      }
-      return estimation;
-    },
     async handleTxReview(): Promise<void> {
       if (this.inputAsset === undefined) {
         return;
@@ -364,22 +347,21 @@ export default Vue.extend({
 
       this.isProcessing = true;
       try {
-        const gasLimits = await this.estimateAction(
-          this.inputAmount,
-          this.inputAsset
-        );
+        const gasLimits = await (
+          this.smartTreasuryOnChainService as SmartTreasuryOnChainService
+        ).estimateDepositCompound(this.inputAsset, this.inputAmount);
 
         this.actionGasLimit = gasLimits.actionGasLimit;
         this.approveGasLimit = gasLimits.approveGasLimit;
+
+        this.step = 'review';
       } catch (error) {
         this.isProcessing = false;
         console.warn('Failed to estimate transaction', error);
         Sentry.captureException(error);
-        return;
+      } finally {
+        this.isProcessing = false;
       }
-
-      this.isProcessing = false;
-      this.step = 'review';
     },
     async handleTxStart(): Promise<void> {
       if (this.inputAsset === undefined) {

--- a/src/views/treasury/treasury-increase-wrapper.vue
+++ b/src/views/treasury/treasury-increase-wrapper.vue
@@ -56,6 +56,7 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 
 import * as Sentry from '@sentry/vue';
 
+import { sendGlobalTopMessageEvent } from '@/global-event-bus';
 import { SmartTreasuryOnChainService } from '@/services/v2/on-chain/mover/smart-treasury';
 import { Modal as ModalType } from '@/store/modules/modals/types';
 import { sameAddress } from '@/utils/address';
@@ -356,7 +357,10 @@ export default Vue.extend({
 
         this.step = 'review';
       } catch (error) {
-        this.isProcessing = false;
+        sendGlobalTopMessageEvent(
+          this.$t('errors.estimationFailed') as string,
+          'error'
+        );
         console.warn('Failed to estimate transaction', error);
         Sentry.captureException(error);
       } finally {

--- a/src/wallet/actions/debit-card/top-up/top-up.ts
+++ b/src/wallet/actions/debit-card/top-up/top-up.ts
@@ -121,15 +121,6 @@ export const topUpCompound = async (
         accountAddress
       );
 
-      if (resp.error) {
-        addSentryBreadcrumb({
-          type: 'error',
-          category: 'debit-card.top-up.unwrap.extimation',
-          message: 'failed estimate after the unwarp'
-        });
-        throw new Error("Can't estimate topup after unwrap");
-      }
-
       topupActionGasLimit = resp.actionGasLimit;
       topupApproveGasLimit = resp.approveGasLimit;
     } catch (err) {
@@ -212,15 +203,6 @@ export const topUpCompound = async (
         accountAddress
       );
 
-      if (resp.error) {
-        addSentryBreadcrumb({
-          type: 'error',
-          category: 'debit-card.top-up.unstake.estimation',
-          message: 'Failed to estimate top up after unstake'
-        });
-        throw new Error("Can't estimate top up after unstake");
-      }
-
       topupActionGasLimit = resp.actionGasLimit;
       topupApproveGasLimit = resp.approveGasLimit;
     } catch (err) {
@@ -245,8 +227,8 @@ export const topUpCompound = async (
       topupInputAmount,
       accountAddress,
       web3,
-      async () => {
-        await topUp(
+      async (newGasLimit) =>
+        topUp(
           topupInputAsset,
           outputAsset,
           topupInputAmount,
@@ -255,12 +237,22 @@ export const topUpCompound = async (
           web3,
           accountAddress,
           changeStepToProcess,
-          topupActionGasLimit,
+          newGasLimit,
           gasPriceInGwei
-        );
-      },
+        ),
+      () =>
+        estimateTopUpCompound(
+          inputAsset,
+          outputAsset,
+          inputAmount,
+          transferData,
+          network,
+          web3,
+          accountAddress
+        ),
       () => changeStepToProcess('Process'),
       topupApproveGasLimit,
+      topupActionGasLimit,
       gasPriceInGwei
     );
   } catch (err) {

--- a/src/wallet/actions/debit-card/top-up/wxBTRFLY/estimate.ts
+++ b/src/wallet/actions/debit-card/top-up/wxBTRFLY/estimate.ts
@@ -2,6 +2,7 @@ import Web3 from 'web3';
 import { ContractSendMethod } from 'web3-eth-contract';
 import { AbiItem } from 'web3-utils';
 
+import { OnChainServiceError } from '@/services/v2/on-chain';
 import { addSentryBreadcrumb } from '@/services/v2/utils/sentry';
 import { floorDivide, toWei } from '@/utils/bigmath';
 import { multiply } from '@/utils/bigmath';
@@ -70,8 +71,6 @@ export const estimateWXBTRFLYUnwrap = async (
       });
 
       return { error: false, gasLimit: gasLimitWithBuffer };
-    } else {
-      throw new Error('empty gas limit');
     }
   } catch (error) {
     addSentryBreadcrumb({
@@ -82,11 +81,13 @@ export const estimateWXBTRFLYUnwrap = async (
         error
       }
     });
-    console.error("can't estimate WxBtrflyUnwrap", error);
 
-    return {
-      error: true,
-      gasLimit: '0'
-    };
+    throw new OnChainServiceError('Failed to estimate WXBTRFLY unwrap').wrap(
+      error
+    );
   }
+
+  throw new OnChainServiceError(
+    'Failed to estimate WXBTRFLY unwrap: empty gas limit'
+  );
 };


### PR DESCRIPTION
Context
* GasLimit too high / too low for a given transaction
* Opaque gas estimations

What was done
* Added ability to estimate tx again after successful approve tx
* Applied for each known use case (services)
* Updated estimation usages

TODO:
[ ] Resolve all TBD (see commit messages)
[x] debit-card-top-up actions -- apply the same fix / rewrite
[x] also patch executeTransactionWithApprove, executeTransactionWithApproveExt, OnChainService.executeTransactionWithApproveExt