### PR TITLE
[Fix] Allow passing the `unknown` type to the wrap() method of MoverError

### DIFF
--- a/src/services/v2/MoverError.ts
+++ b/src/services/v2/MoverError.ts
@@ -3,12 +3,12 @@ import { CustomError } from 'ts-custom-error';
 
 import { addSentryBreadcrumb } from '@/services/v2/utils/sentry';
 
-export class MoverError<T = void> extends CustomError {
-  protected payload?: T;
+export class MoverError extends CustomError {
+  protected payload?: Record<string, unknown>;
   protected wrappedError?: Error;
   protected originalMessage: string;
 
-  constructor(message: string, payload?: T) {
+  constructor(message: string, payload?: Record<string, unknown>) {
     super(message);
     this.originalMessage = message;
     this.payload = payload;
@@ -32,18 +32,26 @@ export class MoverError<T = void> extends CustomError {
     return `${baseString}: ${wrappedErrorString}`;
   }
 
-  public wrap(error: Error): this {
+  public wrap(error: unknown): this {
+    if (!(error instanceof Error)) {
+      this.setPayload({
+        previousPayload: this.payload,
+        wrapped: error
+      });
+      return this;
+    }
+
     this.message = this.formatMessage(error);
     this.wrappedError = error;
     return this;
   }
 
-  public setPayload(payload: T): this {
+  public setPayload(payload: Record<string, unknown>): this {
     this.payload = payload;
     return this;
   }
 
-  public getPayload(): T | undefined {
+  public getPayload(): Record<string, unknown> | undefined {
     return this.payload;
   }
 

--- a/src/services/v2/api/mover/MoverAPIError.ts
+++ b/src/services/v2/api/mover/MoverAPIError.ts
@@ -1,10 +1,10 @@
 import { MoverError } from '@/services/v2/MoverError';
 
-export class MoverAPIError<T = void> extends MoverError<T> {
+export class MoverAPIError extends MoverError {
   constructor(
     readonly message: string,
     readonly shortMessage?: string,
-    readonly payload?: T
+    readonly payload?: Record<string, unknown>
   ) {
     super(message, payload);
   }

--- a/src/services/v2/api/mover/MoverAPIService.ts
+++ b/src/services/v2/api/mover/MoverAPIService.ts
@@ -121,7 +121,10 @@ export abstract class MoverAPIService extends MultiChainAPIService {
     });
 
     instance.interceptors.response.use(
-      <T, E>(
+      <
+        T extends Record<string, unknown> | undefined,
+        E extends Record<string, unknown> | undefined
+      >(
         response: AxiosResponse<MoverAPIResponse<T, E>>
       ):
         | AxiosResponse<MoverAPISuccessfulResponse<T>>
@@ -139,10 +142,16 @@ export abstract class MoverAPIService extends MultiChainAPIService {
             }
           });
 
+          const errorPayload =
+            typeof response.data.payload === 'object' &&
+            !Array.isArray(response.data.payload)
+              ? response.data.payload
+              : { responsePayload: response.data.payload };
+
           const error = new MoverAPIError(
             response.data.error,
             response.data.errorCode,
-            response.data.payload
+            errorPayload
           );
           this.formatError(error);
         }

--- a/src/services/v2/api/mover/subsidized/MoverAPISubsidizedRequestError.ts
+++ b/src/services/v2/api/mover/subsidized/MoverAPISubsidizedRequestError.ts
@@ -1,5 +1,5 @@
 import { MoverAPIError } from '@/services/v2/api/mover/MoverAPIError';
 
-export class MoverAPISubsidizedRequestError<T = void> extends MoverAPIError<T> {
+export class MoverAPISubsidizedRequestError extends MoverAPIError {
   // TODO: some additional data?
 }

--- a/src/services/v2/api/theGraph/CurrencyNotSupportedError.ts
+++ b/src/services/v2/api/theGraph/CurrencyNotSupportedError.ts
@@ -1,5 +1,8 @@
 import { MoverError } from '@/services/v2';
+import { toArray } from '@/utils/arrays';
 
-export class CurrencyNotSupportedError extends MoverError<
-  string | Array<string>
-> {}
+export class CurrencyNotSupportedError extends MoverError {
+  constructor(message: string, currencies: string | Array<string>) {
+    super(message, { currencies: toArray(currencies) });
+  }
+}

--- a/src/services/v2/api/theGraph/TheGraphAPIService.ts
+++ b/src/services/v2/api/theGraph/TheGraphAPIService.ts
@@ -84,7 +84,7 @@ export class TheGraphAPIService extends MultiChainAPIService {
         }
       });
       if (res.errors !== undefined) {
-        throw new MoverError('Failed to execute query', res.errors);
+        throw new MoverError('Failed to execute query', { errors: res.errors });
       }
       const ethPriceUSD = res.data.bundle.ethPrice;
 

--- a/src/services/v2/on-chain/OnChainServiceError.ts
+++ b/src/services/v2/on-chain/OnChainServiceError.ts
@@ -1,7 +1,7 @@
 import { MoverError } from '../MoverError';
 
-export class OnChainServiceError<T> extends MoverError<T> {
-  constructor(message: string, payload?: T) {
+export class OnChainServiceError extends MoverError {
+  constructor(message: string, payload?: Record<string, unknown>) {
     super(message, payload);
   }
 }

--- a/src/services/v2/on-chain/mover/smart-treasury/SmartTreasuryOnChainService.ts
+++ b/src/services/v2/on-chain/mover/smart-treasury/SmartTreasuryOnChainService.ts
@@ -466,7 +466,7 @@ export class SmartTreasuryOnChainService
     ) {
       throw new OnChainServiceError(
         'Wrong token used for Smart Treasury Deposit',
-        inputAsset
+        { inputAsset }
       );
     }
 
@@ -578,7 +578,7 @@ export class SmartTreasuryOnChainService
     ) {
       throw new OnChainServiceError(
         'Wrong token used for Smart Treasury Withdraw',
-        outputAsset
+        { outputAsset }
       );
     }
 
@@ -1241,7 +1241,7 @@ export class SmartTreasuryOnChainService
     ) {
       throw new OnChainServiceError(
         'Wrong token used for Smart Treasury Deposit',
-        inputAsset
+        { inputAsset }
       );
     }
 
@@ -1296,7 +1296,7 @@ export class SmartTreasuryOnChainService
     ) {
       throw new OnChainServiceError(
         'Wrong token used for Smart Treasury Withdraw',
-        outputAsset
+        { outputAsset }
       );
     }
 

--- a/src/services/v2/on-chain/mover/staking-ubt/StakingUbtOnChainService.ts
+++ b/src/services/v2/on-chain/mover/staking-ubt/StakingUbtOnChainService.ts
@@ -60,7 +60,7 @@ export class StakingUbtOnChainService extends MoverOnChainService {
     if (!sameAddress(inputAsset.address, this.UBTAssetData.address)) {
       throw new OnChainServiceError(
         'Wrong token supplied to depositCompound()',
-        inputAsset
+        { inputAsset }
       );
     }
 
@@ -104,7 +104,7 @@ export class StakingUbtOnChainService extends MoverOnChainService {
     if (!sameAddress(inputAsset.address, this.UBTAssetData.address)) {
       throw new OnChainServiceError(
         'Wrong token supplied to estimateDepositCompound()',
-        inputAsset
+        { inputAsset }
       );
     }
 
@@ -206,7 +206,7 @@ export class StakingUbtOnChainService extends MoverOnChainService {
     if (!sameAddress(outputAsset.address, this.UBTAssetData.address)) {
       throw new OnChainServiceError(
         'Wrong token supplied to withdrawCompound()',
-        outputAsset
+        { outputAsset }
       );
     }
 


### PR DESCRIPTION
Context
* Typically the `catch` section has `error` of type `unknown`. We almost certainly know that this argument is `instanceof Error`
* Code completion services throw warnings
* There might be a case where custom Object / primitive is thrown instead of Error-derivative

What was done
* Updated `wrap()` method to use `unknown` instead
* Also enforced the .payload type to Record<string, unknown> | undefined only