### PR TITLE
[Fix] Remove console debug entries from UNS/ENS code

### DIFF
--- a/src/store/modules/nft/actions.ts
+++ b/src/store/modules/nft/actions.ts
@@ -144,9 +144,7 @@ const actions: ActionFuncs<Actions, NFTStoreState, MutationType, GetterType> = {
           commit('setENSAPIService', apiService);
         }
 
-        console.debug('ens name', ensOwnDomainName);
         const tokenId = onChainService.getERC721TokenId(ensOwnDomainName);
-        console.debug('tokenId', tokenId);
         const meta = await apiService.getERC721Meta(tokenId);
         commit('setENSData', meta);
       }


### PR DESCRIPTION
Context
* Some debug info was left

What was done
* Removed `console.debug` entries from `/store/modules/nft/actions.ts`