### PR TITLE
Fix: Add `warning` Sentry level

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -178,7 +178,7 @@ export default Vue.extend({
             .logout(uauthOptions)
             .catch((error) => {
               addSentryBreadcrumb({
-                type: 'warn',
+                type: 'warning',
                 category: 'app',
                 message: 'Failed to log out from Unstoppable Domains client',
                 data: {

--- a/src/services/v2/utils/sentry.ts
+++ b/src/services/v2/utils/sentry.ts
@@ -15,6 +15,9 @@ if (isConsoleEnabled()) {
       case 'info':
         console.info(breadcrumb.message, breadcrumb);
         break;
+      case 'warning':
+        console.warn(breadcrumb.message, breadcrumb);
+        break;
       case 'debug':
         console.debug(breadcrumb.message, breadcrumb);
         break;

--- a/src/store/modules/account/actions.ts
+++ b/src/store/modules/account/actions.ts
@@ -380,7 +380,7 @@ const actions: ActionFuncs<
         })
         .catch((error) => {
           addSentryBreadcrumb({
-            type: 'warn',
+            type: 'warning',
             data: error,
             category: 'refreshWallet.action.account.store',
             message:
@@ -735,7 +735,7 @@ const actions: ActionFuncs<
 
     await state.uauthClient.logout(uauthOptions).catch((error) => {
       addSentryBreadcrumb({
-        type: 'warn',
+        type: 'warning',
         category: 'disconnectWallet.action.account.store',
         message: 'Failed to log out from Unstoppable Domains client',
         data: {

--- a/src/store/modules/nft/actions.ts
+++ b/src/store/modules/nft/actions.ts
@@ -115,7 +115,7 @@ const actions: ActionFuncs<Actions, NFTStoreState, MutationType, GetterType> = {
   async fetchENSData({ rootState, state, commit }): Promise<void> {
     if (!ensureAccountStateIsSafe(rootState.account)) {
       addSentryBreadcrumb({
-        type: 'warn',
+        type: 'warning',
         category: 'fetchENSData.action.nft.store',
         message: 'Account state is not loaded yet'
       });
@@ -164,7 +164,7 @@ const actions: ActionFuncs<Actions, NFTStoreState, MutationType, GetterType> = {
   async fetchUNSData({ rootState, state, commit }): Promise<void> {
     if (!ensureAccountStateIsSafe(rootState.account)) {
       addSentryBreadcrumb({
-        type: 'warn',
+        type: 'warning',
         category: 'fetchUNSData.action.nft.store',
         message: 'Account state is not loaded yet'
       });

--- a/src/views/connect-wallet.vue
+++ b/src/views/connect-wallet.vue
@@ -189,7 +189,7 @@ export default Vue.extend({
         });
         await new UAuthSPA(uauthOptions).logout(uauthOptions).catch((error) => {
           addSentryBreadcrumb({
-            type: 'warn',
+            type: 'warning',
             category: 'app',
             message: 'Failed to log out from Unstoppable Domains client',
             data: {


### PR DESCRIPTION
Context
* Utility function was missing the `warning` level so entries were never shown unless viewed in the Sentry
* Local development was missing the `warning` level logs

What was done
* Added `warning` level to the utility